### PR TITLE
Shahzeb/feat/populate-university-and-address-data-in-admission-program

### DIFF
--- a/src/programs/controllers/programs.controller.ts
+++ b/src/programs/controllers/programs.controller.ts
@@ -48,6 +48,15 @@ export class ProgramsController {
         return this.programsService.findByCampus(campusId, queryDto);
     }
 
+    // get all programs by university
+    @Get('university/:universityId')
+    findByUniversity(
+        @Param('universityId') universityId: string,
+        @Query() queryDto: QueryProgramDto
+    ) {
+        return this.programsService.findAllByUniversity(universityId, queryDto);
+    }
+
     @Get('academic-department/:departmentId')
     findByAcademicDepartment(
         @Param('departmentId') departmentId: string,

--- a/src/programs/dto/query-program.dto.ts
+++ b/src/programs/dto/query-program.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsNumber, IsBoolean, IsArray } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class QueryProgramDto {
@@ -22,16 +22,28 @@ export class QueryProgramDto {
     @IsString()
     campus_id?: string;
 
+    /** This will be used to filter based on multiple campus_id fields */
+    @IsOptional()
+    @IsArray()
+    @IsString({ each: true })
+    campus_ids?: string[];
+
+    @IsOptional()
+    @IsString()
+    degree_level?: string;
+
     @IsOptional()
     @IsString()
     academic_departments?: string;
 
     @IsOptional()
     @Type(() => Number)
+    @IsNumber()
     page?: number = 1;
 
     @IsOptional()
     @Type(() => Number)
+    @IsNumber()
     limit?: number = 10;
 
     @IsOptional()
@@ -44,5 +56,6 @@ export class QueryProgramDto {
 
     @IsOptional()
     @Type(() => Boolean)
+    @IsBoolean()
     populate?: boolean = true;
 } 

--- a/src/programs/schemas/program.schema.ts
+++ b/src/programs/schemas/program.schema.ts
@@ -12,6 +12,9 @@ export class Program {
     major?: string;
 
     @Prop({ type: String, required: false })
+    degree_level?: string;
+
+    @Prop({ type: String, required: false })
     accreditations?: string;
 
     @Prop({ type: String, required: false })

--- a/src/programs/services/programs.service.ts
+++ b/src/programs/services/programs.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types, SortOrder } from 'mongoose';
+import { Model, Types, SortOrder, RootFilterQuery } from 'mongoose';
 import { Program, ProgramDocument } from '../schemas/program.schema';
 import { CreateProgramDto } from '../dto/create-program.dto';
 import { UpdateProgramDto } from '../dto/update-program.dto';
@@ -13,35 +13,19 @@ export class ProgramsService {
         @InjectModel(Program.name) private programModel: Model<ProgramDocument>,
     ) { }
 
-    async create(createProgramDto: CreateProgramDto): Promise<ProgramDocument> {
-        try {
-            const createdProgram = new this.programModel(createProgramDto);
-            return await createdProgram.save();
-        } catch (error) {
-            if (error.name === 'ValidationError') {
-                throw new BadRequestException(error.message);
-            }
-            throw error;
-        }
-    }
-
-    async findAll(queryDto: QueryProgramDto): Promise<{ programs: ProgramDocument[], total: number, page: number, limit: number, totalPages: number }> {
+    private buildFilterQuery(queryDto: QueryProgramDto): RootFilterQuery<ProgramDocument> {
         const {
             search,
             name,
             major,
             mode_of_study,
             campus_id,
+            campus_ids,
+            degree_level,
             academic_departments,
-            page = 1,
-            limit = 10,
-            sortBy = 'createdAt',
-            sortOrder = 'desc',
-            populate = true
         } = queryDto;
 
-        const skip = (page - 1) * limit;
-        const filter: any = {};
+        const filter: RootFilterQuery<ProgramDocument> = {};
 
         // Apply filters
         if (search) {
@@ -63,13 +47,48 @@ export class ProgramsService {
             filter.mode_of_study = { $regex: mode_of_study, $options: 'i' };
         }
 
-        if (campus_id) {
+        if (degree_level) {
+            filter.degree_level = { $regex: degree_level, $options: 'i' };
+        }
+
+        // Handle both single campus_id and multiple campus_ids
+        if (campus_ids?.length) {
+            filter.campus_id = { $in: campus_ids };
+        } else if (campus_id) {
             filter.campus_id = campus_id;
         }
 
         if (academic_departments) {
             filter.academic_departments = academic_departments;
         }
+
+        return filter;
+    }
+
+    async create(createProgramDto: CreateProgramDto): Promise<ProgramDocument> {
+        try {
+            const createdProgram = new this.programModel(createProgramDto);
+            return await createdProgram.save();
+        } catch (error) {
+            if (error.name === 'ValidationError') {
+                throw new BadRequestException(error.message);
+            }
+            throw error;
+        }
+    }
+
+
+    async findAll(queryDto: QueryProgramDto): Promise<{ programs: ProgramDocument[], total: number, page: number, limit: number, totalPages: number }> {
+        const {
+            page = 1,
+            limit = 10,
+            sortBy = 'createdAt',
+            sortOrder = 'desc',
+            populate = true
+        } = queryDto;
+
+        const skip = (page - 1) * limit;
+        const filter = this.buildFilterQuery(queryDto);
 
         // Sort options
         const sort: { [key: string]: SortOrder } = {};
@@ -87,15 +106,8 @@ export class ProgramsService {
         const total = await this.programModel.countDocuments(filter).exec();
         const totalPages = Math.ceil(total / limit);
 
-        // Populate references if requested
         if (populate) {
-            // You would implement population logic here based on your schema relationships
-            // For example:
-            // await Promise.all(programs.map(async (program) => {
-            //   // Populate campus
-            //   // Populate academic departments
-            //   // etc.
-            // }));
+            // Implement population logic here if needed
         }
 
         return {
@@ -422,17 +434,7 @@ export class ProgramsService {
             throw new BadRequestException('Invalid university ID');
         }
 
-        const {
-            page = 1,
-            limit = 10,
-            sortBy = 'createdAt',
-            sortOrder = 'desc',
-            populate = true
-        } = queryDto;
-
-        const skip = (page - 1) * limit;
-
-        // First get all campus IDs for this university using aggregation
+        // Get campus IDs for the university
         const campusesAggregation = await this.programModel.aggregate([
             {
                 $lookup: {
@@ -454,60 +456,29 @@ export class ProgramsService {
                 }
             },
             {
-                $match: {
-                    'campus': { $ne: [] }
-                }
+                $match: { 'campus': { $ne: [] } }
             },
             {
-                $group: {
-                    _id: '$campus_id'
-                }
+                $group: { _id: '$campus_id' }
             }
         ]).exec();
 
         const campusIds = campusesAggregation.map(item => item._id);
 
-        // If no campuses found, return empty result
         if (campusIds.length === 0) {
             return {
                 programs: [],
                 total: 0,
-                page,
-                limit,
+                page: 1,
+                limit: queryDto.limit || 10,
                 totalPages: 0
             };
         }
 
-        // Sort options
-        const sort: { [key: string]: SortOrder } = {};
-        sort[sortBy] = sortOrder === 'asc' ? 1 : -1;
-
-        // Find all programs for these campuses
-        const programs = await this.programModel
-            .find({ campus_id: { $in: campusIds } })
-            .sort(sort)
-            .skip(skip)
-            .limit(limit)
-            .exec();
-
-        // Get total count
-        const total = await this.programModel
-            .countDocuments({ campus_id: { $in: campusIds } })
-            .exec();
-
-        const totalPages = Math.ceil(total / limit);
-
-        // Populate references if requested
-        if (populate) {
-            // Implement population logic here if needed
-        }
-
-        return {
-            programs,
-            total,
-            page,
-            limit,
-            totalPages
-        };
+        // Merge the campus IDs with the query DTO and reuse findAll
+        return this.findAll({
+            ...queryDto,
+            campus_ids: campusIds
+        });
     }
 } 


### PR DESCRIPTION
Adds a new service to find all propgrams offered by the university irrespective of the campuses.
Implementation:
- Refactor the filtering logic for schema keys i.e. mode_of_study, degree_level etc.
- Get all the campuses of the selected university and user that as `campus_ids` filter in the `findAll` service to get programs from all campuses of a university.