### PR TITLE
implement response-time-tracking for chat messages in each session of a conversation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+
+# feature-plan.md
+**/*feature-plan*.md
+**/*feature-plan/*

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "resend": "^4.1.2",
     "rxjs": "^7.8.1",
     "slugify": "^1.6.6",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.7.0",

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,21 +9,13 @@ import { User, UserDocument } from 'src/users/schemas/user.schema';
 import { BetterOmit } from 'src/utils/typescript.utils';
 import { UsersService } from '../users/users.service';
 import { sendEmail } from '../utils/mail.config';
+import { AccessTokenPayload } from 'src/auth/types/auth.interface';
+import { RefreshTokenPayload } from 'src/auth/types/auth.interface';
 
 type UserWithoutComparePassword = BetterOmit<User, 'comparePassword'> & {
     _id: string;
 };
 export type SanitizedUser = BetterOmit<UserWithoutComparePassword, 'hash' | 'salt' | 'password'>;
-
-export interface AccessTokenPayload extends SanitizedUser {
-  sub: string;
-  userId: string;
-}
-
-export interface RefreshTokenPayload {
-  userId: string;
-  sub: string;
-}
 
 @Injectable()
 export class AuthService {

--- a/src/auth/guards/refresh-authentication.guard.ts
+++ b/src/auth/guards/refresh-authentication.guard.ts
@@ -19,12 +19,12 @@ export class RefreshAuthenticationGuard extends AuthGuard(
   handleRequest(err, user, info, context) {
     // check if the user is authenticated
     if (err || !user) {
-      console.log(` ResourceProtectionGuard: handleRequest:`, {
-        err,
-        user,
-        info,
-        context,
-      });
+      // console.log(` ResourceProtectionGuard: handleRequest:`, {
+      //   err,
+      //   user,
+      //   info,
+      //   context,
+      // });
 
       // check if the token is not found
       if (info.message === 'No auth token') {

--- a/src/auth/guards/resource-protection.guard.ts
+++ b/src/auth/guards/resource-protection.guard.ts
@@ -23,12 +23,12 @@ export class ResourceProtectionGuard extends AuthGuard(
   handleRequest(err, user, info, context) {
     // check if the user is authenticated
     if (err || !user) {
-      console.log(` ResourceProtectionGuard: handleRequest:`, {
-        err,
-        user,
-        info,
-        context,
-      });
+      // console.log(` ResourceProtectionGuard: handleRequest:`, {
+      //   err,
+      //   user,
+      //   info,
+      //   context,
+      // });
 
       // check if the token is not found
       if (info.message === 'No auth token') {

--- a/src/auth/strategies/local-authentication.strategy.ts
+++ b/src/auth/strategies/local-authentication.strategy.ts
@@ -17,6 +17,13 @@ export class LocalAuthenticationStrategy extends PassportStrategy(
     });
   }
 
+  /**
+   * This method verifies the user's credentials and returns the user object.
+   * The actual payload for tokens is generated and signed in the `auth.service.login` method.
+   * @param email 
+   * @param password 
+   * @returns 
+   */
   async validate(email: string, password: string) {
     const user = await this.authService.validateAndGetUserData_v1({
       email,

--- a/src/auth/strategies/refresh-authentication.strategy.ts
+++ b/src/auth/strategies/refresh-authentication.strategy.ts
@@ -3,8 +3,9 @@ import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { Request } from 'express';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { AuthService, RefreshTokenPayload } from 'src/auth/auth.service';
+import { AuthService, } from 'src/auth/auth.service';
 import { AuthStrategyEnum } from 'src/auth/strategies/strategy.enum';
+import { RefreshTokenPayload } from 'src/auth/types/auth.interface';
 import { IConfiguration } from 'src/config/configuration';
 import { UsersService } from 'src/users/users.service';
 

--- a/src/auth/strategies/resource-protection.strategy.ts
+++ b/src/auth/strategies/resource-protection.strategy.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { AccessTokenPayload } from 'src/auth/auth.service';
 import { AuthStrategyEnum } from 'src/auth/strategies/strategy.enum';
+import { AccessTokenPayload } from 'src/auth/types/auth.interface';
 import { IConfiguration } from 'src/config/configuration';
 
 @Injectable()
@@ -19,9 +19,7 @@ export class ResourceProtectionStrategy extends PassportStrategy(
     });
   }
 
-  // TODO: How to handle the error (to show the expiry error to user)
   async validate(payload: AccessTokenPayload) {
-    // Customize the payload for v2 as needed
     return payload;
   }
 }

--- a/src/auth/types/auth.interface.ts
+++ b/src/auth/types/auth.interface.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express';
+import { SanitizedUser } from '../auth.service'; // adjust path as needed
+import { ResourceProtectionStrategy } from 'src/auth/strategies/resource-protection.strategy';
+
+export interface AccessTokenPayload extends SanitizedUser {
+    sub: string;
+    userId: string;
+}
+
+export interface RefreshTokenPayload {
+    userId: string;
+    sub: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+    user: Awaited<ReturnType<ResourceProtectionStrategy['validate']>>;
+}

--- a/src/chat/chat-session.service.ts
+++ b/src/chat/chat-session.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { Model, Types } from 'mongoose';
+import { v4 as uuidv4 } from 'uuid';
+import { Message, MessageDocument } from './schemas/message.schema';
+import { ConfigService } from '@nestjs/config';
+import { IConfiguration } from 'src/config/configuration';
+import { EnvValidationSchema } from 'src/config';
+
+@Injectable()
+export class ChatSessionService {
+    constructor(
+        private readonly messageModel: Model<MessageDocument>,
+        private readonly configService: ConfigService<IConfiguration & EnvValidationSchema>,
+    ) { }
+
+    // Helper: Check if session is valid (last message from student and <1hr old)
+    isSessionValid(now: Date, lastMessageTime?: Date): boolean {
+        if (!lastMessageTime) return false;
+        const diffMs = now.getTime() - new Date(lastMessageTime).getTime();
+        const timeout = this.configService.get('app.chatSessionTimeout', { infer: true });
+
+        return diffMs < timeout;
+    }
+
+    // Helper: Get last message in conversation which belongs to a session
+    async getLatestValidSessionMessage(conversationId: Types.ObjectId): Promise<MessageDocument | null> {
+        return this.messageModel.findOne({
+            conversation_id: conversationId,
+            // sessionId should be truthy
+            sessionId: { $exists: true, $ne: null }
+        })
+            .sort({ created_at: -1 })
+            .exec();
+    }
+
+
+    // Helper: Get first student message in session
+    async getFirstStudentMessageInSession(conversationId: Types.ObjectId, sessionId: string): Promise<MessageDocument | null> {
+        return this.messageModel.findOne({ conversation_id: conversationId, sender_type: 'user', sessionId })
+            .sort({ created_at: 1 })
+            .exec();
+    }
+
+    // Helper: Is this the first campus reply in the session?
+    async isFirstCampusReplyInSession(conversationId: Types.ObjectId, sessionId: string): Promise<boolean> {
+        const count = await this.messageModel.countDocuments({ conversation_id: conversationId, sender_type: 'campus', sessionId });
+        return count === 0;
+    }
+
+    // Helper: Calculate response time in ms
+    calculateResponseTime(start: Date, end: Date): number {
+        return end.getTime() - start.getTime();
+    }
+
+    generateSessionId(conversationId: Types.ObjectId | string): string {
+        return `${conversationId.toString()}-${uuidv4()}`;
+    }
+} 

--- a/src/chat/chat-session.service.ts
+++ b/src/chat/chat-session.service.ts
@@ -1,20 +1,22 @@
-import { Injectable } from '@nestjs/common';
-import { Model, Types } from 'mongoose';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types, UpdateQuery } from 'mongoose';
+import { ConversationDocument } from 'src/chat/schemas/conversation.schema';
+import { EnvValidationSchema } from 'src/config';
+import { IConfiguration } from 'src/config/configuration';
 import { v4 as uuidv4 } from 'uuid';
 import { Message, MessageDocument } from './schemas/message.schema';
-import { ConfigService } from '@nestjs/config';
-import { IConfiguration } from 'src/config/configuration';
-import { EnvValidationSchema } from 'src/config';
 
 @Injectable()
 export class ChatSessionService {
     constructor(
-        private readonly messageModel: Model<MessageDocument>,
+        @InjectModel(Message.name) private readonly messageModel: Model<MessageDocument>,
         private readonly configService: ConfigService<IConfiguration & EnvValidationSchema>,
     ) { }
 
     // Helper: Check if session is valid (last message from student and <1hr old)
-    isSessionValid(now: Date, lastMessageTime?: Date): boolean {
+    private isSessionValid(now: Date, lastMessageTime?: Date): boolean {
         if (!lastMessageTime) return false;
         const diffMs = now.getTime() - new Date(lastMessageTime).getTime();
         const timeout = this.configService.get('app.chatSessionTimeout', { infer: true });
@@ -23,9 +25,9 @@ export class ChatSessionService {
     }
 
     // Helper: Get last message in conversation which belongs to a session
-    async getLatestValidSessionMessage(conversationId: Types.ObjectId): Promise<MessageDocument | null> {
+    private async getLatestValidSessionMessage(conversationId: string): Promise<MessageDocument | null> {
         return this.messageModel.findOne({
-            conversation_id: conversationId,
+            conversation_id: new Types.ObjectId(conversationId),
             // sessionId should be truthy
             sessionId: { $exists: true, $ne: null }
         })
@@ -35,24 +37,90 @@ export class ChatSessionService {
 
 
     // Helper: Get first student message in session
-    async getFirstStudentMessageInSession(conversationId: Types.ObjectId, sessionId: string): Promise<MessageDocument | null> {
+    private async getFirstStudentMessageInSession(conversationId: Types.ObjectId, sessionId: string): Promise<MessageDocument | null> {
         return this.messageModel.findOne({ conversation_id: conversationId, sender_type: 'user', sessionId })
             .sort({ created_at: 1 })
             .exec();
     }
 
     // Helper: Is this the first campus reply in the session?
-    async isFirstCampusReplyInSession(conversationId: Types.ObjectId, sessionId: string): Promise<boolean> {
+    private async isFirstCampusReplyInSession(conversationId: Types.ObjectId, sessionId: string): Promise<boolean> {
         const count = await this.messageModel.countDocuments({ conversation_id: conversationId, sender_type: 'campus', sessionId });
         return count === 0;
     }
 
     // Helper: Calculate response time in ms
-    calculateResponseTime(start: Date, end: Date): number {
+    private calculateResponseTime(start: Date, end: Date): number {
         return end.getTime() - start.getTime();
     }
 
-    generateSessionId(conversationId: Types.ObjectId | string): string {
-        return `${conversationId.toString()}-${uuidv4()}`;
+    private generateSessionId(conversationId: string): string {
+        return `${conversationId}-${uuidv4()}`;
+    }
+
+    /**
+     * Handles all session management logic for message creation.
+     * Returns sessionId, conversationDocUpdate, and any other session-related data needed by ChatService.
+     */
+    async handleSessionOnMessage({
+        conversation,
+        senderType,
+        curMsgTime,
+        conversationId,
+    }: {
+        conversation: ConversationDocument,
+        senderType: 'user' | 'campus',
+            curMsgTime: Date,
+        conversationId: Types.ObjectId,
+    }) {
+
+
+        // Get last message in this conversation
+        const latestValidSessionMessage = await this.getLatestValidSessionMessage(conversationId.toString());
+
+
+        let sessionId = latestValidSessionMessage?.sessionId;
+        let conversationDocUpdate: UpdateQuery<ConversationDocument> = {};
+        const DEFAULT_RESPONSE = {
+            sessionId,
+            conversationDocUpdate,
+        };
+
+        // Check session validity
+        const sessionValid = this.isSessionValid(curMsgTime, latestValidSessionMessage?.created_at);
+
+        if (sessionValid && senderType === 'campus') {
+            const isFirstCampusReplyInSession = await this.isFirstCampusReplyInSession(conversationId, sessionId);
+            if (!isFirstCampusReplyInSession) return DEFAULT_RESPONSE;
+
+            const firstStudentMsg = await this.getFirstStudentMessageInSession(conversationId, sessionId);
+            if (!firstStudentMsg) throw new NotFoundException('First student message not found in this session'); // since each session is initialized with a student message, this should never happen
+
+            const currentResponseTime = this.calculateResponseTime(firstStudentMsg.created_at, curMsgTime);
+            const existingAvgResponseTime = conversation?.avgResponseTime;
+            const existingSessionsCount = conversation?.sessionsCount;
+            const isPrevAvgAndSessionCountExists = existingAvgResponseTime > 0 && existingSessionsCount > 0;
+
+
+            if (isPrevAvgAndSessionCountExists) {
+                const sessionsCountBeforeCurrentSession = existingSessionsCount - 1;
+                const existingTotalResponseTime = existingAvgResponseTime * sessionsCountBeforeCurrentSession;
+                const newTotalResponseTime = existingTotalResponseTime + currentResponseTime;
+                const newAvgResponseTime = newTotalResponseTime / existingSessionsCount;
+                conversationDocUpdate.avgResponseTime = newAvgResponseTime;
+            } else {
+                conversationDocUpdate.avgResponseTime = currentResponseTime;
+            }
+
+        } else if (!sessionValid && senderType === 'user') {
+            // New session
+            sessionId = this.generateSessionId(conversationId.toString());
+            conversationDocUpdate.$inc = { sessionsCount: 1 };
+        }
+        return {
+            sessionId,
+            conversationDocUpdate,
+        };
+
     }
 } 

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -19,6 +19,7 @@ import { CreateMessageDto } from './dto/create-message.dto';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
 import { ResourceProtectionGuard } from '../auth/guards/resource-protection.guard';
 import { ChatGateway } from './chat.gateway';
+import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
 
 @Controller('chat')
 @UseGuards(ResourceProtectionGuard)
@@ -31,7 +32,7 @@ export class ChatController {
   @Post('conversations')
   async createConversation(
     @Body() createConversationDto: CreateConversationDto,
-    @Req() req,
+    @Req() req: AuthenticatedRequest,
   ) {
     try {
       // Get user ID from JWT token
@@ -72,7 +73,7 @@ export class ChatController {
   @Get('conversations/campus/:campusId')
   findAllConversationsForCampus(
     @Param('campusId') campusId: string,
-    @Req() req: any,
+    @Req() req: AuthenticatedRequest,
   ) {
     // Here you would typically check if the user has admin rights for this campus
     // This is a placeholder for your authorization logic
@@ -117,7 +118,7 @@ export class ChatController {
   @Post('messages/user')
   async createUserMessage(
     @Body() createMessageDto: CreateMessageDto,
-    @Req() req,
+    @Req() req: AuthenticatedRequest, // TODO: Is this authenticated request?
   ) {
     try {
       const userId = req.user.sub;
@@ -159,7 +160,7 @@ export class ChatController {
   @Post('messages/campus')
   async createCampusMessage(
     @Body() createMessageDto: CreateMessageDto,
-    @Req() req,
+    @Req() req: AuthenticatedRequest,
   ) {
     try {
       // Get user info from token

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -9,6 +9,7 @@ import { User, UserSchema } from '../users/schemas/user.schema';
 import { Campus, CampusSchema } from '../campuses/schemas/campus.schema';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ChatSessionService } from './chat-session.service';
 
 @Module({
     imports: [
@@ -28,7 +29,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
         }),
     ],
     controllers: [ChatController],
-    providers: [ChatService, ChatGateway],
-    exports: [ChatService, ChatGateway],
+    providers: [ChatService, ChatGateway, ChatSessionService],
+    exports: [ChatService, ChatGateway, ChatSessionService],
 })
 export class ChatModule { } 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -172,7 +172,48 @@ export class ChatService {
 
         return { message: 'Conversation deleted successfully' };
     }
-
+    /**
+     * * How to "check for session validity" (a session is always started from a student message)
+     * ? isSentByStudent AND isLastMessageInConversionFresh (gap < 1hr)
+     * 
+     * * How to "update average response time" 
+     * get the existing sessionsCount 
+     * TODO: calculate the current session's responseTime
+     * TODO: check if responseTime exists in the conversation already
+     * ? isResponseTimeExists,
+     *      calculate the avgResponseTime ((prevAvg * prevCount + currentResponseTime) / newCount) and update field
+     * ? isResponseTimeNotExists,
+     *   -   store the current session's response as averageResponseTime
+     * 
+     * * How to "calculate the current session's responseTime"
+     * get the first student message in this conversation
+     * TODO: timeDiff(currentMessageTime - timeOfFirstStudentMessageInThisSession)
+     * 
+     * 
+     * * On each new message
+     * TODO: get sender type of the message => senderType
+     * TODO: check for session validity
+     * ? isExistingSessionValid:
+     *   ? isSentByStudent (senderType === 'user'), 
+     *       1.2a.1 do nothing;
+     *   ? isSentByCampus,
+     *       TODO: check if this is the first message from campus in this session
+     *       ? isCurrentMessageTheFirstCampusMessageInSession,
+     *           TODO: update average response time
+     *       ? isCurrentMessageNotTheFirstCampusMessageInSession,
+     *       -   do nothing;
+     * ? isExistingSessionInvalid:
+     *   ? isSentByStudent, 
+     *       -   update sessionsCount
+     *   ? isSentByCampus,
+     *       -   do nothing;
+     * 
+     * 
+     * @param createMessageDto 
+     * @param userId 
+     * @param senderType 
+     * @returns 
+     */
     async createMessage(createMessageDto: CreateMessageDto, userId: string, senderType: 'user' | 'campus'): Promise<Message> {
         try {
             // Validate IDs
@@ -216,6 +257,10 @@ export class ChatService {
                 attachments: createMessageDto.attachments || [],
                 created_at: new Date()
             };
+
+
+
+
 
             // If this is a campus message, store the user who replied
             if (senderType === 'campus') {

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -197,12 +197,6 @@ export class ChatService {
             .exec();
     }
 
-    // Helper: Get last student message in conversation (optionally for a session)
-    private async getLastStudentMessage(conversationId: Types.ObjectId, sessionId?: number): Promise<MessageDocument | null> {
-        const query: any = { conversation_id: conversationId, sender_type: 'user' };
-        if (sessionId !== undefined) query.sessionId = sessionId;
-        return this.messageModel.findOne(query).sort({ created_at: -1 }).exec();
-    }
 
     // Helper: Get first student message in session
     private async getFirstStudentMessageInSession(conversationId: Types.ObjectId, sessionId: number): Promise<MessageDocument | null> {

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -8,6 +8,9 @@ import { Campus, CampusDocument } from '../campuses/schemas/campus.schema';
 import { CreateConversationDto } from './dto/create-conversation.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
+import { ConfigService } from '@nestjs/config';
+import { IConfiguration } from 'src/config/configuration';
+import { EnvValidationSchema } from 'src/config';
 
 @Injectable()
 export class ChatService {
@@ -16,6 +19,7 @@ export class ChatService {
         @InjectModel(Message.name) private messageModel: Model<MessageDocument>,
         @InjectModel(User.name) private userModel: Model<UserDocument>,
         @InjectModel(Campus.name) private campusModel: Model<CampusDocument>,
+        private readonly configService: ConfigService<IConfiguration & EnvValidationSchema>
     ) { }
 
     async createConversation(createConversationDto: CreateConversationDto, userId: string): Promise<Conversation> {
@@ -177,7 +181,7 @@ export class ChatService {
     private isSessionValid(lastMessage: MessageDocument, now: Date): boolean {
         if (!lastMessage) return false;
         const diffMs = now.getTime() - new Date(lastMessage.created_at).getTime();
-        return diffMs < 60 * 60 * 1000; // 1 hour
+        return diffMs < this.configService.get('app.chatSessionTimeout', { infer: true });
     }
 
     // Helper: Get last message in conversation

--- a/src/chat/schemas/conversation.schema.ts
+++ b/src/chat/schemas/conversation.schema.ts
@@ -28,6 +28,13 @@ export class Conversation {
 
     @Prop({ type: String, enum: ['user', 'campus'], default: 'user' })
     last_message_sender: string;
+
+    @Prop({ type: Number, default: 0 })
+    avgResponseTime: number;
+
+    @Prop({ type: Number, default: 0 })
+    sessionsCount: number;
+
 }
 
 export const ConversationSchema = SchemaFactory.createForClass(Conversation);

--- a/src/chat/schemas/message.schema.ts
+++ b/src/chat/schemas/message.schema.ts
@@ -42,6 +42,9 @@ export class Message {
 
     @Prop({ type: MongooseSchema.Types.Mixed })
     sender: any;
+
+    @Prop({ type: Number, default: 0 })
+    sessionId: number;
 }
 
 export const MessageSchema = SchemaFactory.createForClass(Message); 

--- a/src/chat/schemas/message.schema.ts
+++ b/src/chat/schemas/message.schema.ts
@@ -43,8 +43,8 @@ export class Message {
     @Prop({ type: MongooseSchema.Types.Mixed })
     sender: any;
 
-    @Prop({ type: Number, default: 0 })
-    sessionId: number;
+    @Prop({ type: String, default: null })
+    sessionId: string;
 }
 
 export const MessageSchema = SchemaFactory.createForClass(Message); 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -42,6 +42,7 @@ const configuration = () => {
             port: parsedEnv.PORT || 3010,
             nodeEnv: parsedEnv.NODE_ENV,
             payloadSecret: parsedEnv.PAYLOAD_SECRET,
+            chatSessionTimeout: parsedEnv.CHAT_SESSION_TIMEOUT
         },
         s3: {
             endpoint: parsedEnv.S3_ENDPOINT,

--- a/src/config/validation/env.validation.ts
+++ b/src/config/validation/env.validation.ts
@@ -21,6 +21,7 @@ export interface EnvValidationSchema {
     PORT: number;
     NODE_ENV: string;
     PAYLOAD_SECRET: string;
+    CHAT_SESSION_TIMEOUT: number;
 
     // S3 Configuration
     S3_ENDPOINT: string;
@@ -90,6 +91,7 @@ export const envValidationSchema = Joi.object<EnvValidationSchema>({
     PORT: Joi.number().default(3010),
     NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
     PAYLOAD_SECRET: Joi.string().required(),
+    CHAT_SESSION_TIMEOUT: Joi.number().default(1 * 60 * 60 * 1000), // 1 hour
 
     // S3 Configuration
     S3_ENDPOINT: Joi.string().required().uri(),


### PR DESCRIPTION
### 📌 Summary

This PR implements logic to track **average response time** of university representatives (campus users) and manages **session validity** based on student activity. A **session** is defined as a continuous conversation **withing the session timeout** where the **first message is always from the student**.  (messages from the campus don't initiate any session)

---

### ✅ What’s Implemented

#### 1. **Session Validity Check**

* A session is considered **valid** if:

  * The latest message is from a student
  * And the gap between the current message and the last message in the conversation is **less than 1 hour**
* Otherwise, the session is considered **invalid**, and a **new session is started** when a student sends a new message.

#### 2. **Session Tracking**

* On each **student message**, we check session validity:

  * If the session is invalid → increment `sessionsCount` and assign a new `sessionId`
* On **campus message**, we determine whether it’s the **first campus response** in the session.

#### 3. **Average Response Time Calculation**

* When the **first campus message** in a session is received:

  * We calculate the response time from the **first student message of that session**.
  * If `averageResponseTime` already exists:

    * Update it using:

      ```
      avg = (prevAvg * prevCount + currentResponseTime) / newCount
      ```
  * If not:

    * Store `currentResponseTime` as the new average.

---

### 🔁 Logic Flow Summary

* On **each new message**:

  * Get the `senderType`
  * Check for **session validity**

    * If session is valid:

      * If `senderType === student`: do nothing
      * If `senderType === campus`:

        * If it's their **first response in this session**, update average response time
        * Else, ignore
    * If session is invalid:

      * If `senderType === student`: start a new session (increment session count & ID)
      * If `senderType === campus`: do nothing

---

### ⚠️ Edge Cases Addressed

* Campus messages without a valid student-initiated session do not initiate a new session
* Only **first** campus message in a session is counted toward average response time
* Session expiry threshold set at **1 hour gap** (but is configurable)
