### PR TITLE
fix(student-scholarships): add support for province and district of domicile

### DIFF
--- a/src/student-scholarships/dto/create-student-scholarship.dto.ts
+++ b/src/student-scholarships/dto/create-student-scholarship.dto.ts
@@ -21,16 +21,12 @@ export class LastDegreeDto {
 
 // student_snapshot DTO
 export class StudentSnapshotDto {
-    @IsString()
-    @IsEnum(FatherLivingStatusEnum)
-    father_status: FatherLivingStatusEnum;
+  @IsString()
+  monthly_household_income: string;
 
-    @IsString()
-    monthly_household_income: string;
-
-    @ValidateNested()
-    @Type(() => LastDegreeDto)
-    last_degree: LastDegreeDto;
+  @ValidateNested()
+  @Type(() => LastDegreeDto)
+  last_degree: LastDegreeDto;
 }
 
 export class RequiredDocumentDto {

--- a/src/student-scholarships/schemas/student-scholarship.schema.ts
+++ b/src/student-scholarships/schemas/student-scholarship.schema.ts
@@ -59,7 +59,8 @@ interface IStudentSnapshot {
   name: string;
   father_name: string;
   father_status: FatherLivingStatusEnum;
-  domicile: string;
+  districtOfDomicile: string;
+  provinceOfDomicile: string;
   monthly_household_income: string;
   last_degree: IStudentSnapshotLastDegree;
 }
@@ -111,7 +112,10 @@ class StudentSnapshotDto implements IStudentSnapshot {
   father_status: IStudentSnapshot['father_status'];
 
   @Prop({ type: String, required: true })
-  domicile: IStudentSnapshot['domicile'];
+  districtOfDomicile: IStudentSnapshot['districtOfDomicile'];
+
+  @Prop({ type: String, required: true })
+  provinceOfDomicile: IStudentSnapshot['provinceOfDomicile'];
 
   @Prop({ type: String, required: true })
   monthly_household_income: IStudentSnapshot['monthly_household_income'];

--- a/src/student-scholarships/services/student-scholarships.service.ts
+++ b/src/student-scholarships/services/student-scholarships.service.ts
@@ -45,39 +45,48 @@ export class StudentScholarshipsService {
 
   async createUserSnapshot(
     userId: string,
-    clientSnapshotData: Pick<
+    apiPayloadSnapshotData: Pick<
       IStudentScholarship['student_snapshot'],
-      'last_degree' | 'monthly_household_income' | 'father_status'
+      'last_degree' | 'monthly_household_income'
     >,
   ): Promise<IStudentScholarship['student_snapshot']> {
-    const user = await this.userModel.findById(userId).exec();
+    const userProfile = await this.userModel.findById<User>(userId).exec();
 
-    if (!user) {
+    if (!userProfile) {
       throw new NotFoundException(`User with ID ${userId} not found`);
     }
 
-    if (!user.father_name || !user.provinceOfDomicile) {
+    if (!userProfile.father_name || !userProfile.provinceOfDomicile) {
       throw new BadRequestException(
         'Incomplete data in profile. Please complete your profile to continue.',
       );
     }
 
+    const {
+      first_name,
+      last_name,
+      father_name,
+      father_status,
+      provinceOfDomicile,
+      districtOfDomicile,
+    } = userProfile;
+
+    const { monthly_household_income, last_degree } = apiPayloadSnapshotData;
+
     // Create a partial snapshot with data from the user document
     const userSnapshot: IStudentScholarship['student_snapshot'] = {
-      name: `${user.first_name} ${user.last_name}`,
-      father_name: user.father_name,
-      father_status:
-        clientSnapshotData.father_status ||
-        user.father_status ||
-        FatherLivingStatusEnum.Alive,
-      domicile: user.provinceOfDomicile, // REVIEW: Are we supposed to check the province or district of domicile?
-      monthly_household_income: clientSnapshotData.monthly_household_income,
-      last_degree: clientSnapshotData.last_degree,
+      name: `${first_name} ${last_name}`,
+      father_name,
+      father_status,
+      provinceOfDomicile,
+      districtOfDomicile,
+      monthly_household_income,
+      last_degree,
     };
 
     // Return the partial snapshot - client will need to provide:
     // - monthly_household_income
-    // - last_degree (level and percentage)
+    // - last_degree
     return userSnapshot;
   }
 


### PR DESCRIPTION
- Removed father_status and domicile fields from StudentSnapshotDto, replacing them with districtOfDomicile and provinceOfDomicile.
- Adjusted createUserSnapshot method to reflect changes in the user profile structure and ensure proper data handling.
- Enhanced error handling for incomplete user profiles during snapshot creation.