### PR TITLE
Feat/shahzeb/sb-329

### DIFF
--- a/src/admission-programs/controllers/admission-programs.controller.ts
+++ b/src/admission-programs/controllers/admission-programs.controller.ts
@@ -19,6 +19,9 @@ import { UpdateAdmissionProgramDto } from '../dto/update-admission-program.dto';
 import { AdmissionProgramsService } from '../services/admission-programs.service';
 import { QueryAdmissionProgramDegreeLevelsDto } from '../dto/query-admission-program-degree-levels.dto';
 import { QueryAdmissionProgramMajorsDto } from '../dto/query-admission-program-majors.dto';
+import { AuthReq } from 'src/auth/decorators/auth-req.decorator';
+import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
+import { QueryAdmissionProgramByIdDto } from '../dto/query-admission-program.dto';
 
 @Controller('admission-programs')
 export class AdmissionProgramsController {
@@ -40,28 +43,42 @@ export class AdmissionProgramsController {
 
   // /degree-levels
   @Get('degree-levels')
-  findAllDegreeLevels(@Query() queryAdmissionProgramDegreeLevelsDto: QueryAdmissionProgramDegreeLevelsDto) {
-    return this.admissionProgramsService.findAllDegreeLevels(queryAdmissionProgramDegreeLevelsDto);
+  findAllDegreeLevels(
+    @Query()
+    queryAdmissionProgramDegreeLevelsDto: QueryAdmissionProgramDegreeLevelsDto,
+  ) {
+    return this.admissionProgramsService.findAllDegreeLevels(
+      queryAdmissionProgramDegreeLevelsDto,
+    );
   }
 
   // /majors
   @Get('majors')
-  findAllMajors(@Query() queryAdmissionProgramMajorsDto: QueryAdmissionProgramMajorsDto) {
-    return this.admissionProgramsService.findAllMajors(queryAdmissionProgramMajorsDto);
+  findAllMajors(
+    @Query() queryAdmissionProgramMajorsDto: QueryAdmissionProgramMajorsDto,
+  ) {
+    return this.admissionProgramsService.findAllMajors(
+      queryAdmissionProgramMajorsDto,
+    );
   }
-  
 
   @Get()
   findAll(@Query() queryDto: QueryAdmissionProgramDto) {
     return this.admissionProgramsService.findAll(queryDto);
   }
 
-  @Get('by-id/:id')
+  @UseGuards(ResourceProtectionGuard)
+  @Get(':admission_program_id')
   findOne(
-    @Param('id') id: string,
-    @Query('populate') populate: boolean = true,
+    @AuthReq() authReq: AuthenticatedRequest,
+    @Param('admission_program_id') admission_program_id: string,
+    @Query() queryDto: QueryAdmissionProgramByIdDto,
   ) {
-    return this.admissionProgramsService.findOne(id, populate);
+    return this.admissionProgramsService.findOne(
+      admission_program_id,
+      authReq.user,
+      queryDto,
+    );
   }
 
   @UseGuards(ResourceProtectionGuard)

--- a/src/admission-programs/dto/query-admission-program.dto.ts
+++ b/src/admission-programs/dto/query-admission-program.dto.ts
@@ -1,54 +1,64 @@
-import { IsOptional, IsString, IsMongoId, IsNumber, IsBoolean, IsArray } from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  IsMongoId,
+  IsNumber,
+  IsBoolean,
+  IsArray,
+} from 'class-validator';
 import { Type } from 'class-transformer';
+import { PopulateDto } from 'src/common/dto/populate.dto';
 
 export class QueryAdmissionProgramDto {
-    @IsOptional()
-    @IsString()
-    search?: string;
+  @IsOptional()
+  @IsString()
+  search?: string;
 
-    @IsOptional()
-    @IsMongoId()
-    admission?: string;
+  @IsOptional()
+  @IsMongoId()
+  admission?: string;
 
-    @IsOptional()
-    @IsMongoId()
-    program?: string;
+  @IsOptional()
+  @IsMongoId()
+  program?: string;
 
-    @IsOptional()
-    @IsArray()
-    @IsMongoId({ each: true })
-    favouriteBy?: string[];
+  @IsOptional()
+  @IsArray()
+  @IsMongoId({ each: true })
+  favouriteBy?: string[];
 
-    @IsOptional()
-    @IsNumber()
-    @Type(() => Number)
-    minAvailableSeats?: number;
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  minAvailableSeats?: number;
 
-    @IsOptional()
-    @IsNumber()
-    @Type(() => Number)
-    maxAvailableSeats?: number;
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  maxAvailableSeats?: number;
 
-    @IsOptional()
-    @IsNumber()
-    @Type(() => Number)
-    page?: number = 1;
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  page?: number = 1;
 
-    @IsOptional()
-    @IsNumber()
-    @Type(() => Number)
-    limit?: number = 10;
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  limit?: number = 10;
 
-    @IsOptional()
-    @IsString()
-    sortBy?: string = 'createdAt';
+  @IsOptional()
+  @IsString()
+  sortBy?: string = 'createdAt';
 
-    @IsOptional()
-    @IsString()
-    sortOrder?: 'asc' | 'desc' = 'desc';
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc' = 'desc';
 
-    @IsOptional()
-    @IsBoolean()
-    @Type(() => Boolean)
-    populate?: boolean = true;
-} 
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  populate?: boolean = true;
+}
+
+export class QueryAdmissionProgramByIdDto extends PopulateDto {}

--- a/src/admission-programs/schemas/admission-program.schema.ts
+++ b/src/admission-programs/schemas/admission-program.schema.ts
@@ -1,63 +1,69 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Schema as MongooseSchema } from 'mongoose';
+import { Document, Types } from 'mongoose';
 
 export type AdmissionProgramDocument = AdmissionProgram & Document;
 
 interface AdmissionRequirementValue {
-    children: Array<{
-        bold?: boolean;
-        italic?: boolean;
-        underline?: boolean;
-        text?: string;
-        type?: string;
-        children?: any[];
-        url?: string;
-        newTab?: boolean;
-        code?: boolean;
-    }>;
+  children: Array<{
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    text?: string;
     type?: string;
+    children?: any[];
+    url?: string;
+    newTab?: boolean;
+    code?: boolean;
+  }>;
+  type?: string;
 }
 
 interface AdmissionRequirement {
-    id: string;
-    key: string;
-    value: AdmissionRequirementValue[];
+  id: string;
+  key: string;
+  value: AdmissionRequirementValue[];
 }
 
 @Schema({ timestamps: true, collection: 'admission_programs' })
 export class AdmissionProgram {
-    @Prop({ type: String, ref: 'Admission' })
-    admission: string;
+  @Prop({ type: String, ref: 'Admission' })
+  admission: string;
 
-    @Prop({ type: String })
-    admission_fee: string;
+  @Prop({ type: String })
+  admission_fee: string;
 
-    @Prop({
-        type: [{
-            id: { type: String, required: true },
-            key: { type: String, required: true },
-            value: { type: Array, required: true }
-        }]
-    })
-    admission_requirements: AdmissionRequirement[];
+  @Prop({
+    type: [
+      {
+        id: { type: String, required: true },
+        key: { type: String, required: true },
+        value: { type: Array, required: true },
+      },
+    ],
+  })
+  admission_requirements: AdmissionRequirement[];
 
-    @Prop({ type: Number, required: true })
-    available_seats: number;
+  @Prop({ type: Number, required: true })
+  available_seats: number;
 
-    @Prop({ type: Date })
-    created_at: Date;
+  @Prop({ type: Date })
+  created_at: Date;
 
-    @Prop({ type: String, ref: 'User' })
-    createdBy: string;
+  @Prop({ type: String, ref: 'User' })
+  createdBy: string;
 
-    @Prop({ type: [String], default: [] })
-    favouriteBy: string[];
+  @Prop({ type: [String], default: [] })
+  favouriteBy: string[];
 
-    @Prop({ type: String, ref: 'Program', required: true })
-    program: string;
+  @Prop({ type: String, ref: 'Program', required: true })
+  program: string;
 
-    @Prop({ type: String })
-    redirect_deeplink: string;
+  @Prop({ type: String })
+  redirect_deeplink: string;
+
+  @Prop({ type: [Types.ObjectId], default: [], ref: 'User' })
+  redirect_students: Types.ObjectId[];
 }
 
-export const AdmissionProgramSchema = SchemaFactory.createForClass(AdmissionProgram); 
+export const AdmissionProgramSchema =
+  SchemaFactory.createForClass(AdmissionProgram);

--- a/src/admission-programs/schemas/admission-program.schema.ts
+++ b/src/admission-programs/schemas/admission-program.schema.ts
@@ -62,7 +62,7 @@ export class AdmissionProgram {
   redirect_deeplink: string;
 
   @Prop({ type: [Types.ObjectId], default: [], ref: 'User' })
-  redirect_students: Types.ObjectId[];
+  redirected_students: Types.ObjectId[];
 }
 
 export const AdmissionProgramSchema =

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -34,6 +34,7 @@ import { IConfiguration } from 'src/config/configuration';
 import { AnalyticsModule } from './analytics/analytics.module';
 import { NotificationModule } from './notification/notification.module';
 import { LegalDocumentsModule } from './legal-documents/legal-documents.module';
+import { ExternalApplicationsModule } from './external-applications/external-applications.module';
 
 @Module({
   imports: [
@@ -70,6 +71,7 @@ import { LegalDocumentsModule } from './legal-documents/legal-documents.module';
     AdmissionsModule,
     AdmissionProgramsModule,
     ApplicationsModule,
+    ExternalApplicationsModule,
     ContactUsModule,
     FeesModule,
     ProgramTemplatesModule,

--- a/src/applications/controllers/applications.controller.ts
+++ b/src/applications/controllers/applications.controller.ts
@@ -34,7 +34,7 @@ export class ApplicationsController {
   ) {
     // Pass the user ID to the service to fetch user data and create application
     return this.applicationsService.createWithUserSnapshot(
-      authReq.user.sub,
+      authReq.user,
       createApplicationDto,
     );
   }

--- a/src/applications/controllers/applications.controller.ts
+++ b/src/applications/controllers/applications.controller.ts
@@ -20,11 +20,11 @@ import { Roles } from '../../auth/decorators/roles.decorator';
 import { Role } from '../../auth/enums/role.enum';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 
+@UseGuards(ResourceProtectionGuard)
 @Controller('applications')
 export class ApplicationsController {
   constructor(private readonly applicationsService: ApplicationsService) {}
 
-  @UseGuards(ResourceProtectionGuard)
   @Post()
   async create(@Body() createApplicationDto: CreateApplicationDto, @Req() req) {
     // Get the user ID from the JWT token
@@ -37,20 +37,18 @@ export class ApplicationsController {
     );
   }
 
-  @UseGuards(ResourceProtectionGuard, RolesGuard)
+  @UseGuards(RolesGuard)
   // @Roles(Role.ADMIN, Role.CAMPUS_ADMIN)
   @Get()
   findAll(@Query() queryDto: QueryApplicationDto) {
     return this.applicationsService.findAll(queryDto);
   }
 
-  @UseGuards(ResourceProtectionGuard)
   @Get('my-applications')
   findMyApplications(@Req() req, @Query() queryDto: QueryApplicationDto) {
     return this.applicationsService.findByApplicant(req.user.sub, queryDto);
   }
 
-  @UseGuards(ResourceProtectionGuard)
   @Get('statistics')
   getStatistics() {
     return this.applicationsService.getApplicationStatistics();
@@ -61,7 +59,6 @@ export class ApplicationsController {
     return this.applicationsService.getApplicationLegalDocuments();
   }
 
-  @UseGuards(ResourceProtectionGuard)
   @Get(':id')
   findOne(
     @Param('id') id: string,
@@ -70,7 +67,6 @@ export class ApplicationsController {
     return this.applicationsService.findOne(id, populate);
   }
 
-  @UseGuards(ResourceProtectionGuard)
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -79,21 +75,21 @@ export class ApplicationsController {
     return this.applicationsService.update(id, updateApplicationDto);
   }
 
-  @UseGuards(ResourceProtectionGuard, RolesGuard)
+  @UseGuards(RolesGuard)
   @Roles(Role.ADMIN, Role.CAMPUS_ADMIN)
   @Patch(':id/status')
   updateStatus(@Param('id') id: string, @Body('status') status: string) {
     return this.applicationsService.updateStatus(id, status);
   }
 
-  @UseGuards(ResourceProtectionGuard, RolesGuard)
+  @UseGuards(RolesGuard)
   @Roles(Role.ADMIN, Role.CAMPUS_ADMIN)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.applicationsService.remove(id);
   }
 
-  @UseGuards(ResourceProtectionGuard, RolesGuard)
+  @UseGuards(RolesGuard)
   @Roles(Role.ADMIN, Role.CAMPUS_ADMIN)
   @Post('update-application-status')
   async updateApplicationStatus(

--- a/src/applications/controllers/applications.controller.ts
+++ b/src/applications/controllers/applications.controller.ts
@@ -19,6 +19,8 @@ import { ResourceProtectionGuard } from '../../auth/guards/resource-protection.g
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { Role } from '../../auth/enums/role.enum';
 import { RolesGuard } from '../../auth/guards/roles.guard';
+import { AuthReq } from 'src/auth/decorators/auth-req.decorator';
+import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
 
 @UseGuards(ResourceProtectionGuard)
 @Controller('applications')
@@ -26,14 +28,14 @@ export class ApplicationsController {
   constructor(private readonly applicationsService: ApplicationsService) {}
 
   @Post()
-  async create(@Body() createApplicationDto: CreateApplicationDto, @Req() req) {
-    // Get the user ID from the JWT token
-    const userId = req.user.sub;
-
+  async create(
+    @AuthReq() authReq: AuthenticatedRequest,
+    @Body() createApplicationDto: CreateApplicationDto,
+  ) {
     // Pass the user ID to the service to fetch user data and create application
     return this.applicationsService.createWithUserSnapshot(
+      authReq.user.sub,
       createApplicationDto,
-      userId,
     );
   }
 

--- a/src/applications/schemas/application.schema.ts
+++ b/src/applications/schemas/application.schema.ts
@@ -25,7 +25,7 @@ interface NationalIdCard {
   back_side: string;
 }
 
-interface ApplicantSnapshot {
+export interface ApplicantSnapshot {
   first_name: string;
   last_name?: string;
   email: string;

--- a/src/applications/schemas/application.schema.ts
+++ b/src/applications/schemas/application.schema.ts
@@ -1,31 +1,15 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Schema as MongooseSchema, Types } from 'mongoose';
-import { EsEntity, EsField } from 'es-mapping-ts';
-import { BaseMappingEntity } from 'src/elasticsearch/mappings/base.mapping';
+import { LivingStatusEnum } from 'src/common/constants/shared.constants';
+import {
+  EducationalBackground,
+  NationalIdCard,
+  UserNS,
+} from '../../users/schemas/user.schema';
 
 export type ApplicationDocument = Application & Document;
 
-// Define nested interfaces for complex types
-interface EducationalBackground {
-  id: string;
-  education_level: string;
-  field_of_study: string;
-  school_college_university: string;
-  board: string;
-  year_of_passing: string;
-  marks_gpa: {
-    obtained_marks_gpa: string;
-    total_marks_gpa: string;
-  };
-  transcript: string;
-}
-
-interface NationalIdCard {
-  front_side: string;
-  back_side: string;
-}
-
-export interface ApplicantSnapshot {
+interface IApplicantSnapshot {
   first_name: string;
   last_name?: string;
   email: string;
@@ -50,6 +34,100 @@ export interface ApplicantSnapshot {
   educational_backgrounds: EducationalBackground[];
   national_id_card: NationalIdCard;
   user_type: string;
+}
+
+@Schema({
+  timestamps: false,
+  _id: false,
+})
+export class ApplicantSnapshot implements IApplicantSnapshot {
+  @Prop({ required: true })
+  first_name: string;
+
+  @Prop({ required: false })
+  last_name?: string;
+
+  @Prop({ required: true })
+  email: string;
+
+  @Prop({ required: true })
+  phone_number: string;
+
+  @Prop({ required: true })
+  date_of_birth: Date;
+
+  @Prop({ required: true })
+  father_name: string;
+
+  @Prop({ required: false })
+  father_profession?: string;
+
+  @Prop({
+    type: String,
+    enum: LivingStatusEnum,
+    required: false,
+  })
+  father_status?: LivingStatusEnum;
+
+  @Prop({ required: false })
+  father_income?: string;
+
+  @Prop({ required: false })
+  mother_name?: string;
+
+  @Prop({ required: false })
+  mother_profession?: string;
+
+  @Prop({ enum: ['alive', 'deceased'], required: false })
+  mother_status?: string;
+
+  @Prop({ required: false })
+  mother_income?: string;
+
+  @Prop({ required: false })
+  religion?: string;
+
+  @Prop({ enum: ['yes', 'no'], required: false })
+  special_person?: string;
+
+  @Prop({ enum: ['Male', 'Female', 'Other'], required: false })
+  gender?: string;
+
+  @Prop({ required: true })
+  nationality: string;
+
+  @Prop({
+    enum: ['khyber_pakhtunkhwa', 'punjab', 'sindh', 'balochistan'],
+    required: true,
+  })
+  provinceOfDomicile: string;
+
+  @Prop({ required: true })
+  districtOfDomicile: string;
+
+  @Prop({ required: true })
+  stateOrProvince: string;
+
+  @Prop({ required: true })
+  city: string;
+
+  @Prop({ required: true })
+  postalCode: string;
+
+  @Prop({ required: true })
+  streetAddress: string;
+
+  @Prop({ required: true })
+  profile_image_url: string;
+
+  @Prop({ required: true, enum: UserNS.UserType })
+  user_type: UserNS.UserType;
+
+  @Prop({ type: [EducationalBackground], default: [] })
+  educational_backgrounds: EducationalBackground[];
+
+  @Prop({ type: NationalIdCard, required: true })
+  national_id_card: NationalIdCard;
 }
 
 interface Preference {
@@ -119,7 +197,7 @@ export class Application {
   @Prop({ type: Number, required: true })
   total_processing_fee: number;
 
-  @Prop({ type: MongooseSchema.Types.Mixed, required: true })
+  @Prop({ type: ApplicantSnapshot, required: true })
   applicant_snapshot: ApplicantSnapshot;
 
   //   An array of legal document ids that the applicant has accepted

--- a/src/applications/schemas/application.schema.ts
+++ b/src/applications/schemas/application.schema.ts
@@ -94,9 +94,6 @@ export class Application {
   })
   admission_id: MongooseSchema.Types.ObjectId;
 
-  @Prop({ type: String, ref: 'User' })
-  applicant_id: string;
-
   @Prop({ type: String, ref: 'User', required: true })
   applicant: string;
 

--- a/src/applications/schemas/application.schema.ts
+++ b/src/applications/schemas/application.schema.ts
@@ -162,15 +162,15 @@ export class Application {
   @Prop({ type: String, ref: 'User', required: true })
   student_id: string;
 
-  @Prop({ type: MongooseSchema.Types.ObjectId, ref: 'Program', required: true })
-  program_id: MongooseSchema.Types.ObjectId;
+  @Prop({ type: Types.ObjectId, ref: 'Program', required: true })
+  program_id: Types.ObjectId;
 
   @Prop({
-    type: MongooseSchema.Types.ObjectId,
+    type: Types.ObjectId,
     ref: 'Admission',
     required: true,
   })
-  admission_id: MongooseSchema.Types.ObjectId;
+  admission_id: Types.ObjectId;
 
   @Prop({ type: String, ref: 'User', required: true })
   applicant: string;

--- a/src/applications/services/applications.service.ts
+++ b/src/applications/services/applications.service.ts
@@ -18,6 +18,7 @@ import { User, UserDocument } from '../../users/schemas/user.schema';
 import { LegalDocumentRequirementsService } from '../../legal-document-requirements/legal-document-requirements.service';
 import { LegalDocumentsService } from '../../legal-documents/legal-documents.service';
 import { LegalActionType } from '../../legal-document-requirements/schemas/legal-document-requirement.schema';
+import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
 
 @Injectable()
 export class ApplicationsService {
@@ -292,14 +293,14 @@ export class ApplicationsService {
   }
 
   async createWithUserSnapshot(
-    userId: string,
+    user: AuthenticatedRequest['user'],
     createApplicationDto: CreateApplicationDto,
   ): Promise<ApplicationDocument> {
     try {
       // Check if user has already applied for this admission program
       const existingApplication = await this.applicationModel
         .findOne({
-          applicant: userId,
+          applicant: user.sub,
           admission_program_id: createApplicationDto.admission_program_id,
         })
         .exec();
@@ -309,9 +310,6 @@ export class ApplicationsService {
           'Already applied for this admission program.',
         );
       }
-
-      // Fetch the complete user data to create the snapshot
-      const user = await this.userModel.findById(userId).exec();
 
       if (!user) {
         throw new NotFoundException('User not found');
@@ -323,8 +321,8 @@ export class ApplicationsService {
       // Create the application with the snapshot and map fields correctly
       const application = new this.applicationModel({
         ...createApplicationDto,
-        applicant: userId,
-        student_id: userId, // Map applicant to student_id
+        applicant: user._id,
+        student_id: user._id, // Map applicant to student_id
         program_id: createApplicationDto.program, // Map program to program_id
         admission_id: createApplicationDto.admission, // Map admission to admission_id
         applicant_snapshot,
@@ -357,35 +355,65 @@ export class ApplicationsService {
    * @param user The user document to create snapshot from
    * @returns The applicant snapshot object
    */
-  private createApplicantSnapshot(user: UserDocument) {
+  private createApplicantSnapshot(user: AuthenticatedRequest['user']) {
+    const {
+      first_name,
+      last_name,
+      email,
+      phone_number,
+      date_of_birth,
+      father_name,
+      father_profession,
+      father_status,
+      father_income,
+      mother_name,
+      mother_profession,
+      mother_status,
+      mother_income,
+      religion,
+      special_person,
+      gender,
+      nationality,
+      provinceOfDomicile,
+      districtOfDomicile,
+      stateOrProvince,
+      city,
+      postalCode,
+      streetAddress,
+      profile_image_url,
+      user_type,
+      educational_backgrounds,
+      national_id_card,
+    } = user;
+
     return {
-      first_name: user.first_name || null,
-      last_name: user.last_name || null,
-      email: user.email || null,
-      phone_number: user.phone_number || null,
-      date_of_birth: user.date_of_birth || null,
-      father_name: user.father_name || null,
-      father_profession: user.father_profession || null,
-      father_status: user.father_status || null,
-      father_income: user.father_income || null,
-      mother_name: user.mother_name || null,
-      mother_profession: user.mother_profession || null,
-      mother_status: user.mother_status || null,
-      mother_income: user.mother_income || null,
-      religion: user.religion || null,
-      special_person: user.special_person || null,
-      gender: user.gender || null,
-      nationality: user.nationality || null,
-      provinceOfDomicile: user.provinceOfDomicile || null,
-      districtOfDomicile: user.districtOfDomicile || null,
-      stateOrProvince: user.stateOrProvince || null,
-      city: user.city || null,
-      postalCode: user.postalCode || null,
-      streetAddress: user.streetAddress || null,
-      profile_image_url: user.profile_image_url || null,
-      user_type: user.user_type || null,
+      first_name: first_name || null,
+      last_name: last_name || null,
+      email: email || null,
+      phone_number: phone_number || null,
+      date_of_birth: date_of_birth || null,
+      father_name: father_name || null,
+      father_profession: father_profession || null,
+      father_status: father_status || null,
+      father_income: father_income || null,
+      mother_name: mother_name || null,
+      mother_profession: mother_profession || null,
+      mother_status: mother_status || null,
+      mother_income: mother_income || null,
+      religion: religion || null,
+      special_person: special_person || null,
+      gender: gender || null,
+      nationality: nationality || null,
+      provinceOfDomicile: provinceOfDomicile || null,
+      districtOfDomicile: districtOfDomicile || null,
+      stateOrProvince: stateOrProvince || null,
+      city: city || null,
+      postalCode: postalCode || null,
+      streetAddress: streetAddress || null,
+      profile_image_url: profile_image_url || null,
+      user_type: user_type || null,
       educational_backgrounds:
-        user.educational_backgrounds?.map((edu) => ({
+        educational_backgrounds?.map((edu) => ({
           id: edu.id,
           education_level: edu.education_level || null,
           field_of_study: edu.field_of_study || null,
@@ -399,8 +427,8 @@ export class ApplicationsService {
           transcript: edu.transcript || null,
         })) || [],
       national_id_card: {
-        front_side: user.national_id_card?.front_side || null,
-        back_side: user.national_id_card?.back_side || null,
+        front_side: national_id_card?.front_side || null,
+        back_side: national_id_card?.back_side || null,
       },
     };
   }

--- a/src/applications/services/applications.service.ts
+++ b/src/applications/services/applications.service.ts
@@ -31,6 +31,11 @@ export class ApplicationsService {
     private readonly legalDocumentsService: LegalDocumentsService,
   ) {}
 
+  /**
+   * @deprecated Use createWithUserSnapshot instead
+   * @param createApplicationDto - The application data to create
+   * @returns The created application
+   */
   async create(
     createApplicationDto: CreateApplicationDto,
   ): Promise<ApplicationDocument> {
@@ -287,12 +292,10 @@ export class ApplicationsService {
   }
 
   async createWithUserSnapshot(
-    createApplicationDto: CreateApplicationDto,
     userId: string,
+    createApplicationDto: CreateApplicationDto,
   ): Promise<ApplicationDocument> {
     try {
-      // TODO: Check the payload for the associated legal documents required for application
-
       // Check if user has already applied for this admission program
       const existingApplication = await this.applicationModel
         .findOne({
@@ -315,51 +318,7 @@ export class ApplicationsService {
       }
 
       // Create applicant snapshot from user data
-      const applicant_snapshot = {
-        first_name: user.first_name || null,
-        last_name: user.last_name || null,
-        email: user.email || null,
-        phone_number: user.phone_number || null,
-        date_of_birth: user.date_of_birth || null,
-        father_name: user.father_name || null,
-        father_profession: user.father_profession || null,
-        father_status: user.father_status || null,
-        father_income: user.father_income || null,
-        mother_name: user.mother_name || null,
-        mother_profession: user.mother_profession || null,
-        mother_status: user.mother_status || null,
-        mother_income: user.mother_income || null,
-        religion: user.religion || null,
-        special_person: user.special_person || null,
-        gender: user.gender || null,
-        nationality: user.nationality || null,
-        provinceOfDomicile: user.provinceOfDomicile || null,
-        districtOfDomicile: user.districtOfDomicile || null,
-        stateOrProvince: user.stateOrProvince || null,
-        city: user.city || null,
-        postalCode: user.postalCode || null,
-        streetAddress: user.streetAddress || null,
-        profile_image_url: user.profile_image_url || null,
-        user_type: user.user_type || null,
-        educational_backgrounds:
-          user.educational_backgrounds?.map((edu) => ({
-            id: edu.id,
-            education_level: edu.education_level || null,
-            field_of_study: edu.field_of_study || null,
-            school_college_university: edu.school_college_university || null,
-            marks_gpa: {
-              total_marks_gpa: edu.marks_gpa?.total_marks_gpa || null,
-              obtained_marks_gpa: edu.marks_gpa?.obtained_marks_gpa || null,
-            },
-            year_of_passing: edu.year_of_passing || null,
-            board: edu.board || null,
-            transcript: edu.transcript || null,
-          })) || [],
-        national_id_card: {
-          front_side: user.national_id_card?.front_side || null,
-          back_side: user.national_id_card?.back_side || null,
-        },
-      };
+      const applicant_snapshot = this.createApplicantSnapshot(user);
 
       // Create the application with the snapshot and map fields correctly
       const application = new this.applicationModel({
@@ -391,6 +350,59 @@ export class ApplicationsService {
         error.message || 'Error processing application',
       );
     }
+  }
+
+  /**
+   * Creates an applicant snapshot from user data
+   * @param user The user document to create snapshot from
+   * @returns The applicant snapshot object
+   */
+  private createApplicantSnapshot(user: UserDocument) {
+    return {
+      first_name: user.first_name || null,
+      last_name: user.last_name || null,
+      email: user.email || null,
+      phone_number: user.phone_number || null,
+      date_of_birth: user.date_of_birth || null,
+      father_name: user.father_name || null,
+      father_profession: user.father_profession || null,
+      father_status: user.father_status || null,
+      father_income: user.father_income || null,
+      mother_name: user.mother_name || null,
+      mother_profession: user.mother_profession || null,
+      mother_status: user.mother_status || null,
+      mother_income: user.mother_income || null,
+      religion: user.religion || null,
+      special_person: user.special_person || null,
+      gender: user.gender || null,
+      nationality: user.nationality || null,
+      provinceOfDomicile: user.provinceOfDomicile || null,
+      districtOfDomicile: user.districtOfDomicile || null,
+      stateOrProvince: user.stateOrProvince || null,
+      city: user.city || null,
+      postalCode: user.postalCode || null,
+      streetAddress: user.streetAddress || null,
+      profile_image_url: user.profile_image_url || null,
+      user_type: user.user_type || null,
+      educational_backgrounds:
+        user.educational_backgrounds?.map((edu) => ({
+          id: edu.id,
+          education_level: edu.education_level || null,
+          field_of_study: edu.field_of_study || null,
+          school_college_university: edu.school_college_university || null,
+          marks_gpa: {
+            total_marks_gpa: edu.marks_gpa?.total_marks_gpa || null,
+            obtained_marks_gpa: edu.marks_gpa?.obtained_marks_gpa || null,
+          },
+          year_of_passing: edu.year_of_passing || null,
+          board: edu.board || null,
+          transcript: edu.transcript || null,
+        })) || [],
+      national_id_card: {
+        front_side: user.national_id_card?.front_side || null,
+        back_side: user.national_id_card?.back_side || null,
+      },
+    };
   }
 
   private async getLegalDocumentIdsForApplication() {

--- a/src/auth/decorators/is-valid-boolean.decorator.ts
+++ b/src/auth/decorators/is-valid-boolean.decorator.ts
@@ -2,7 +2,7 @@ import { Transform } from 'class-transformer';
 import { IsBoolean } from 'class-validator';
 
 /**
- * Decorator that transforms and validates a value as a boolean.
+ * Decorator that **transforms** and **validates** a value as a boolean.
  * Only accepts 'true', 'false', '1', '0', true, false, 1, 0 as valid inputs.
  * Other values will cause validation to fail.
  *

--- a/src/common/constants/shared.constants.ts
+++ b/src/common/constants/shared.constants.ts
@@ -14,7 +14,7 @@ export enum ScholarshipLocationEnum {
   International = 'international',
 }
 
-export enum FatherLivingStatusEnum {
+export enum LivingStatusEnum {
   Alive = 'alive',
   Deceased = 'deceased',
 }

--- a/src/common/dto/populate.dto.ts
+++ b/src/common/dto/populate.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional } from 'class-validator';
+import { IsValidBoolean } from 'src/auth/decorators/is-valid-boolean.decorator';
+
+export class PopulateDto {
+  @IsOptional()
+  @IsValidBoolean()
+  populate?: boolean;
+}

--- a/src/common/transformers/object-id.transformer.ts
+++ b/src/common/transformers/object-id.transformer.ts
@@ -2,6 +2,21 @@ import { BadRequestException } from '@nestjs/common';
 import { Transform, TransformFnParams } from 'class-transformer';
 import { Types } from 'mongoose';
 
+/**
+ * Transforms a string to a MongoDB ObjectId
+ * @returns Decorator function
+ * @example an example to use it for an array of object ids
+ * ```ts
+ * @IsOptional()
+ * @IsArray()
+ * @IsObjectId({
+ *   each: true,
+ *   message: 'Each document ID must be a valid MongoDB ObjectId',
+ * })
+ * @ToObjectId()
+ * document_ids?: Types.ObjectId[];
+ * ```
+ */
 export function ToObjectId() {
   return function (target: any, key: string) {
     Transform(({ value }: TransformFnParams) => {

--- a/src/common/validators/object-id.validator.ts
+++ b/src/common/validators/object-id.validator.ts
@@ -21,30 +21,36 @@ export class IsValidObjectId implements ValidatorConstraintInterface {
  * Custom validator for MongoDB ObjectId
  * @param validationOptions - Validation options
  * @returns Decorator function
- *
- * @example
+ * @example how to use it for an optional array of object ids
+ * ```ts
  * @IsOptional()
  * @IsArray()
  * @IsObjectId({ each: true, message: 'Each ID must be a valid MongoDB ObjectId' })
  * optional_object_id_array: string[]
- *
- * @example
+ * ```
+ * @example how to use it for a required array of object ids
+ * ```ts
  * @IsArray()
  * @ArrayNotEmpty()
  * @IsObjectId({ each: true, message: 'Each ID must be a valid MongoDB ObjectId' })
  * required_object_id_array: string[]
+ * ```
  *
- * @example
+ * @example how to use it for a required object id
+ * ```ts
  * @IsString()
  * @IsNotEmpty()
  * @IsObjectId({ message: 'ID must be a valid MongoDB ObjectId' })
  * required_object_id: string
+ * ```
  *
- * @example
+ * @example how to use it for an optional object id
+ * ```ts
  * @IsOptional()
  * @IsString()
  * @IsObjectId({ message: 'ID must be a valid MongoDB ObjectId' })
  * optional_object_id: string
+ * ```
  */
 export function IsObjectId(validationOptions?: ValidationOptions) {
   return function (object: Object, propertyName: string) {

--- a/src/external-applications/dto/create-external-application.dto.ts
+++ b/src/external-applications/dto/create-external-application.dto.ts
@@ -1,0 +1,26 @@
+import { IsNotEmpty, IsOptional } from 'class-validator';
+import { Types } from 'mongoose';
+import { ToObjectId } from 'src/common/transformers/object-id.transformer';
+import { IsObjectId } from 'src/common/validators/object-id.validator';
+
+export class CreateExternalApplicationDto {
+  @IsNotEmpty() // required
+  @IsObjectId()
+  @ToObjectId()
+  admission_program: Types.ObjectId;
+
+  @IsNotEmpty() // required
+  @IsObjectId()
+  @ToObjectId()
+  campus: Types.ObjectId;
+
+  @IsNotEmpty() // required
+  @IsObjectId()
+  @ToObjectId()
+  program: Types.ObjectId;
+
+  @IsOptional()
+  @IsObjectId()
+  @ToObjectId()
+  admission: Types.ObjectId;
+}

--- a/src/external-applications/dto/query-external-application.dto.ts
+++ b/src/external-applications/dto/query-external-application.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class QueryExternalApplicationDto extends PaginationDto {}

--- a/src/external-applications/external-applications.controller.ts
+++ b/src/external-applications/external-applications.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthReq } from 'src/auth/decorators/auth-req.decorator';
+import { ResourceProtectionGuard } from 'src/auth/guards/resource-protection.guard';
+import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
+import { CreateExternalApplicationDto } from './dto/create-external-application.dto';
+import { QueryExternalApplicationDto } from './dto/query-external-application.dto';
+import { ExternalApplicationsService } from './external-applications.service';
+
+@Controller('external-applications')
+@UseGuards(ResourceProtectionGuard)
+export class ExternalApplicationsController {
+  constructor(
+    private readonly externalApplicationsService: ExternalApplicationsService,
+  ) {}
+
+  @Post()
+  create(
+    @Body() createExternalApplicationDto: CreateExternalApplicationDto,
+    @Req() req,
+  ) {
+    return this.externalApplicationsService.create(
+      req.user,
+      createExternalApplicationDto,
+    );
+  }
+
+  @Get()
+  findAll(
+    @AuthReq() authReq: AuthenticatedRequest,
+    @Query() queryDto: QueryExternalApplicationDto,
+  ) {
+    return this.externalApplicationsService.findAll(authReq.user, queryDto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string, @Req() req) {
+    return this.externalApplicationsService.findOne(id, req.user.sub);
+  }
+}

--- a/src/external-applications/external-applications.module.ts
+++ b/src/external-applications/external-applications.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ExternalApplicationsService } from './external-applications.service';
+import { ExternalApplicationsController } from './external-applications.controller';
+import {
+  ExternalApplication,
+  ExternalApplicationSchema,
+} from './schemas/external-application.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ExternalApplication.name, schema: ExternalApplicationSchema },
+    ]),
+  ],
+  controllers: [ExternalApplicationsController],
+  providers: [ExternalApplicationsService],
+  exports: [ExternalApplicationsService],
+})
+export class ExternalApplicationsModule {}

--- a/src/external-applications/external-applications.module.ts
+++ b/src/external-applications/external-applications.module.ts
@@ -6,11 +6,16 @@ import {
   ExternalApplication,
   ExternalApplicationSchema,
 } from './schemas/external-application.schema';
+import {
+  AdmissionProgram,
+  AdmissionProgramSchema,
+} from '../admission-programs/schemas/admission-program.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: ExternalApplication.name, schema: ExternalApplicationSchema },
+      { name: AdmissionProgram.name, schema: AdmissionProgramSchema },
     ]),
   ],
   controllers: [ExternalApplicationsController],

--- a/src/external-applications/external-applications.service.ts
+++ b/src/external-applications/external-applications.service.ts
@@ -148,11 +148,11 @@ export class ExternalApplicationsService {
         );
         const savedApplication = await externalApplication.save({ session });
 
-        // Add the student to the admission program's redirect_students array
+        // Add the student to the admission program's redirected_students array
         await this.admissionProgramModel.findByIdAndUpdate(
           admission_program,
           {
-            $addToSet: { redirect_students: stringToObjectId(user._id) },
+            $addToSet: { redirected_students: stringToObjectId(user._id) },
           },
           { new: true, session },
         );

--- a/src/external-applications/external-applications.service.ts
+++ b/src/external-applications/external-applications.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
+import { stringToObjectId } from 'src/utils/db.utils';
+import { CreateExternalApplicationDto } from './dto/create-external-application.dto';
+import { QueryExternalApplicationDto } from './dto/query-external-application.dto';
+import {
+  ExternalApplication,
+  ExternalApplicationDocument,
+} from './schemas/external-application.schema';
+
+interface FindAllOptions {
+  page: number;
+  limit: number;
+  status?: string;
+  campusId?: string;
+  program?: string;
+}
+
+@Injectable()
+export class ExternalApplicationsService {
+  constructor(
+    @InjectModel(ExternalApplication.name)
+    private externalApplicationModel: Model<ExternalApplicationDocument>,
+  ) {}
+  /**
+   * TODO: Check if this method can be integrated with the user service/ user model to make it reusable
+   * Creates an applicant snapshot from user data
+   * @param user The user document to create snapshot from
+   * @returns The applicant snapshot object
+   */
+  private createApplicantSnapshot(user: AuthenticatedRequest['user']) {
+    const {
+      first_name,
+      last_name,
+      email,
+      phone_number,
+      date_of_birth,
+      father_name,
+      father_profession,
+      father_status,
+      father_income,
+      mother_name,
+      mother_profession,
+      mother_status,
+      mother_income,
+      religion,
+      special_person,
+      gender,
+      nationality,
+      provinceOfDomicile,
+      districtOfDomicile,
+      stateOrProvince,
+      city,
+      postalCode,
+      streetAddress,
+      profile_image_url,
+      user_type,
+      educational_backgrounds,
+      national_id_card,
+    } = user;
+
+    return {
+      first_name: first_name || null,
+      last_name: last_name || null,
+      email: email || null,
+      phone_number: phone_number || null,
+      date_of_birth: date_of_birth || null,
+      father_name: father_name || null,
+      father_profession: father_profession || null,
+      father_status: father_status || null,
+      father_income: father_income || null,
+      mother_name: mother_name || null,
+      mother_profession: mother_profession || null,
+      mother_status: mother_status || null,
+      mother_income: mother_income || null,
+      religion: religion || null,
+      special_person: special_person || null,
+      gender: gender || null,
+      nationality: nationality || null,
+      provinceOfDomicile: provinceOfDomicile || null,
+      districtOfDomicile: districtOfDomicile || null,
+      stateOrProvince: stateOrProvince || null,
+      city: city || null,
+      postalCode: postalCode || null,
+      streetAddress: streetAddress || null,
+      profile_image_url: profile_image_url || null,
+      user_type: user_type || null,
+      educational_backgrounds:
+        educational_backgrounds?.map((edu) => ({
+          id: edu.id,
+          education_level: edu.education_level || null,
+          field_of_study: edu.field_of_study || null,
+          school_college_university: edu.school_college_university || null,
+          marks_gpa: {
+            total_marks_gpa: edu.marks_gpa?.total_marks_gpa || null,
+            obtained_marks_gpa: edu.marks_gpa?.obtained_marks_gpa || null,
+          },
+          year_of_passing: edu.year_of_passing || null,
+          board: edu.board || null,
+          transcript: edu.transcript || null,
+        })) || [],
+      national_id_card: {
+        front_side: national_id_card?.front_side || null,
+        back_side: national_id_card?.back_side || null,
+      },
+    };
+  }
+
+  async create(
+    user: AuthenticatedRequest['user'],
+    createExternalApplicationDto: CreateExternalApplicationDto,
+  ) {
+    const { program, admission, admission_program, campus } =
+      createExternalApplicationDto;
+
+    const applicant_snapshot = this.createApplicantSnapshot(user);
+
+    const applicationData: ExternalApplication = {
+      applicant: stringToObjectId(user._id),
+      applicant_snapshot,
+      program,
+      admission,
+      admission_program,
+      campus,
+    };
+
+    const externalApplication = new this.externalApplicationModel(
+      applicationData,
+    );
+    return externalApplication.save();
+  }
+
+  async findAll(
+    user: AuthenticatedRequest['user'],
+    queryDto: QueryExternalApplicationDto,
+  ) {
+    const { page, limit } = queryDto;
+    const skip = (page - 1) * limit;
+
+    const applications = await this.externalApplicationModel
+      .find()
+      .skip(skip)
+      .limit(limit)
+      .sort({ createdAt: -1 })
+      .exec();
+
+    const total = await this.externalApplicationModel.countDocuments();
+
+    return {
+      applications,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async findOne(id: string, userId: string) {
+    const application = await this.externalApplicationModel
+      .findOne({
+        _id: id,
+        student_id: userId,
+      })
+      .populate('program_id', 'name code description')
+      .populate('admission_id', 'title year description')
+      .exec();
+
+    if (!application) {
+      throw new NotFoundException('External application not found');
+    }
+
+    return application;
+  }
+}

--- a/src/external-applications/schemas/external-application.schema.ts
+++ b/src/external-applications/schemas/external-application.schema.ts
@@ -1,82 +1,10 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
+import { ApplicantSnapshot } from 'src/applications/schemas/application.schema';
 
 export type ExternalApplicationDocument = ExternalApplication & Document;
 
-// Define nested interfaces for complex types (reused from application schema)
-interface EducationalBackground {
-  id: string;
-  education_level: string;
-  field_of_study: string;
-  school_college_university: string;
-  board: string;
-  year_of_passing: string;
-  marks_gpa: {
-    obtained_marks_gpa: string;
-    total_marks_gpa: string;
-  };
-  transcript: string;
-}
-
-interface NationalIdCard {
-  front_side: string;
-  back_side: string;
-}
-
-interface ApplicantSnapshot {
-  first_name: string;
-  last_name?: string;
-  email: string;
-  phone_number: string;
-  date_of_birth: Date;
-  gender?: string;
-  nationality: string;
-  cnic?: string;
-  profile_image_url: string;
-  city: string;
-  stateOrProvince: string;
-  streetAddress: string;
-  postalCode: string;
-  districtOfDomicile: string;
-  provinceOfDomicile: string;
-  father_name: string;
-  father_status?: string;
-  father_profession?: string;
-  father_income?: string;
-  religion?: string;
-  special_person?: string;
-  educational_backgrounds: EducationalBackground[];
-  national_id_card: NationalIdCard;
-  user_type: string;
-}
-
-export enum ExternalApplicationStatus {
-  /**
-   * Draft status is used to indicate that the external application is in draft mode and is (created but) not submitted by the user
-   */
-  DRAFT = 'Draft',
-
-  /**
-   * Pending status is used to indicate that the external application is submitted by the user and is pending for approval
-   */
-  PENDING = 'Pending',
-
-  /**
-   * Redirected status indicates that the user has been redirected to external platform
-   */
-  REDIRECTED = 'Redirected',
-
-  /**
-   * Completed status indicates that the external application process has been completed
-   */
-  COMPLETED = 'Completed',
-
-  APPROVED = 'Approved',
-  REJECTED = 'Rejected',
-  UNDER_REVIEW = 'Under Review',
-}
-
-@Schema({ timestamps: true })
+@Schema({ timestamps: true, collection: 'external_applications' })
 export class ExternalApplication {
   @Prop({ type: Types.ObjectId, ref: 'Program', required: true })
   program: Types.ObjectId;

--- a/src/external-applications/schemas/external-application.schema.ts
+++ b/src/external-applications/schemas/external-application.schema.ts
@@ -1,0 +1,105 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type ExternalApplicationDocument = ExternalApplication & Document;
+
+// Define nested interfaces for complex types (reused from application schema)
+interface EducationalBackground {
+  id: string;
+  education_level: string;
+  field_of_study: string;
+  school_college_university: string;
+  board: string;
+  year_of_passing: string;
+  marks_gpa: {
+    obtained_marks_gpa: string;
+    total_marks_gpa: string;
+  };
+  transcript: string;
+}
+
+interface NationalIdCard {
+  front_side: string;
+  back_side: string;
+}
+
+interface ApplicantSnapshot {
+  first_name: string;
+  last_name?: string;
+  email: string;
+  phone_number: string;
+  date_of_birth: Date;
+  gender?: string;
+  nationality: string;
+  cnic?: string;
+  profile_image_url: string;
+  city: string;
+  stateOrProvince: string;
+  streetAddress: string;
+  postalCode: string;
+  districtOfDomicile: string;
+  provinceOfDomicile: string;
+  father_name: string;
+  father_status?: string;
+  father_profession?: string;
+  father_income?: string;
+  religion?: string;
+  special_person?: string;
+  educational_backgrounds: EducationalBackground[];
+  national_id_card: NationalIdCard;
+  user_type: string;
+}
+
+export enum ExternalApplicationStatus {
+  /**
+   * Draft status is used to indicate that the external application is in draft mode and is (created but) not submitted by the user
+   */
+  DRAFT = 'Draft',
+
+  /**
+   * Pending status is used to indicate that the external application is submitted by the user and is pending for approval
+   */
+  PENDING = 'Pending',
+
+  /**
+   * Redirected status indicates that the user has been redirected to external platform
+   */
+  REDIRECTED = 'Redirected',
+
+  /**
+   * Completed status indicates that the external application process has been completed
+   */
+  COMPLETED = 'Completed',
+
+  APPROVED = 'Approved',
+  REJECTED = 'Rejected',
+  UNDER_REVIEW = 'Under Review',
+}
+
+@Schema({ timestamps: true })
+export class ExternalApplication {
+  @Prop({ type: Types.ObjectId, ref: 'Program', required: true })
+  program: Types.ObjectId;
+
+  @Prop({
+    type: Types.ObjectId,
+    ref: 'Admission',
+    required: true,
+  })
+  admission: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  applicant: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'AdmissionProgram', required: true })
+  admission_program: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'Campus', required: true })
+  campus: Types.ObjectId;
+
+  @Prop({ type: Object, required: true })
+  applicant_snapshot: ApplicantSnapshot;
+}
+
+export const ExternalApplicationSchema =
+  SchemaFactory.createForClass(ExternalApplication);

--- a/src/student-scholarships/dto/create-student-scholarship.dto.ts
+++ b/src/student-scholarships/dto/create-student-scholarship.dto.ts
@@ -1,10 +1,21 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsEnum, IsMongoId, IsNotEmpty, IsNumber, IsObject, IsOptional, IsString, IsUrl, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsEnum,
+  IsMongoId,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUrl,
+  ValidateNested,
+} from 'class-validator';
 import { ParseObjectId } from 'nestjs-object-id';
 import { StudentScholarship } from '../schemas/student-scholarship.schema';
 import {
   DegreeLevelEnum,
-  FatherLivingStatusEnum,
+  LivingStatusEnum,
   RequiredDocumentTitleEnum,
 } from 'src/common/constants/shared.constants';
 
@@ -30,15 +41,14 @@ export class StudentSnapshotDto {
 }
 
 export class RequiredDocumentDto {
-    @IsString()
-    @IsEnum(RequiredDocumentTitleEnum)
-    document_name: RequiredDocumentTitleEnum;
+  @IsString()
+  @IsEnum(RequiredDocumentTitleEnum)
+  document_name: RequiredDocumentTitleEnum;
 
-    @IsString()
-    @IsUrl()
-    document_link: string;
+  @IsString()
+  @IsUrl()
+  document_link: string;
 }
-
 
 export class CreateStudentScholarshipDto {
   @IsNotEmpty()

--- a/src/student-scholarships/dto/query-student-scholarship.dto.ts
+++ b/src/student-scholarships/dto/query-student-scholarship.dto.ts
@@ -2,7 +2,7 @@ import { Type } from 'class-transformer';
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { ParseObjectId } from 'nestjs-object-id';
 import { ScholarshipApprovalStatusEnum } from '../schemas/student-scholarship.schema';
-import { FatherLivingStatusEnum } from 'src/common/constants/shared.constants';
+import { LivingStatusEnum } from 'src/common/constants/shared.constants';
 
 export class QueryStudentScholarshipDto {
   @IsOptional()
@@ -18,8 +18,8 @@ export class QueryStudentScholarshipDto {
   search?: string;
 
   @IsOptional()
-  @IsEnum(FatherLivingStatusEnum)
-  father_status?: FatherLivingStatusEnum;
+  @IsEnum(LivingStatusEnum)
+  father_status?: LivingStatusEnum;
 
   @IsOptional()
   @IsEnum(ScholarshipApprovalStatusEnum)

--- a/src/student-scholarships/schemas/student-scholarship.schema.ts
+++ b/src/student-scholarships/schemas/student-scholarship.schema.ts
@@ -1,7 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Schema as MongooseSchema, Types } from 'mongoose';
 import { DegreeLevelEnum } from 'src/common/constants/shared.constants';
-import { FatherLivingStatusEnum } from 'src/common/constants/shared.constants';
+import { LivingStatusEnum } from 'src/common/constants/shared.constants';
 import { RequiredDocumentTitleEnum } from 'src/common/constants/shared.constants';
 
 /* 
@@ -58,7 +58,7 @@ interface IStudentSnapshotLastDegree {
 interface IStudentSnapshot {
   name: string;
   father_name: string;
-  father_status: FatherLivingStatusEnum;
+  father_status: LivingStatusEnum;
   districtOfDomicile: string;
   provinceOfDomicile: string;
   monthly_household_income: string;
@@ -108,7 +108,7 @@ class StudentSnapshotDto implements IStudentSnapshot {
   @Prop({ type: String, required: true })
   father_name: IStudentSnapshot['father_name'];
 
-  @Prop({ type: String, enum: FatherLivingStatusEnum, required: true })
+  @Prop({ type: String, enum: LivingStatusEnum, required: true })
   father_status: IStudentSnapshot['father_status'];
 
   @Prop({ type: String, required: true })
@@ -181,5 +181,6 @@ export class StudentScholarship implements IStudentScholarship {
   createdBy: IStudentScholarship['createdBy'];
 }
 
-export type StudentScholarshipDocument = HydratedDocument<StudentScholarship>
-export const StudentScholarshipSchema = SchemaFactory.createForClass(StudentScholarship);
+export type StudentScholarshipDocument = HydratedDocument<StudentScholarship>;
+export const StudentScholarshipSchema =
+  SchemaFactory.createForClass(StudentScholarship);

--- a/src/student-scholarships/services/student-scholarships.service.ts
+++ b/src/student-scholarships/services/student-scholarships.service.ts
@@ -29,7 +29,7 @@ import {
   StudentScholarship,
   StudentScholarshipDocument,
 } from '../schemas/student-scholarship.schema';
-import { FatherLivingStatusEnum } from 'src/common/constants/shared.constants';
+import { LivingStatusEnum } from 'src/common/constants/shared.constants';
 
 @Injectable()
 export class StudentScholarshipsService {

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -1,35 +1,48 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Schema as MongooseSchema } from 'mongoose';
 import * as bcrypt from 'bcryptjs';
-import { FatherLivingStatusEnum } from 'src/common/constants/shared.constants';
+import { LivingStatusEnum } from 'src/common/constants/shared.constants';
 
-// Educational background interfaces
-export interface IMarksGPA {
-  total_marks_gpa: string;
-  obtained_marks_gpa: string;
+// typescript namespace with all the user type enums
+export namespace UserNS {
+  export enum UserType {
+    Student = 'Student',
+    Admin = 'Admin',
+    Campus_Admin = 'Campus_Admin',
+  }
+  // Educational background interfaces
+  export interface IMarksGPA {
+    total_marks_gpa: string;
+    obtained_marks_gpa: string;
+  }
+
+  export interface IEducationalBackground {
+    id?: string;
+    board?: string; // Optional
+    education_level: string; // Required
+    field_of_study?: string; // Optional
+    marks_gpa: IMarksGPA; // Required
+    school_college_university?: string; // Optional
+    transcript?: string; // Optional
+    year_of_passing?: string; // Optional
+  }
+
+  export interface INationalIdCard {
+    front_side?: string;
+    back_side?: string;
+  }
 }
 
 @Schema({
   timestamps: false,
   _id: false,
 })
-export class MarksGPA implements IMarksGPA {
+export class MarksGPA implements UserNS.IMarksGPA {
   @Prop({ required: true })
   total_marks_gpa: string;
 
   @Prop({ required: true })
   obtained_marks_gpa: string;
-}
-
-export interface IEducationalBackground {
-  id?: string;
-  education_level: string; // Required
-  marks_gpa: IMarksGPA; // Required
-  school_college_university?: string; // Optional
-  field_of_study?: string; // Optional
-  year_of_passing?: string; // Optional
-  board?: string; // Optional
-  transcript?: string; // Optional
 }
 
 // Schema Class for educational background
@@ -37,7 +50,7 @@ export interface IEducationalBackground {
   timestamps: false,
   _id: false,
 })
-export class EducationalBackground implements IEducationalBackground {
+export class EducationalBackground implements UserNS.IEducationalBackground {
   @Prop({ required: false })
   id?: string;
 
@@ -48,7 +61,7 @@ export class EducationalBackground implements IEducationalBackground {
   school_college_university?: string;
 
   @Prop({ type: MarksGPA, required: true })
-  marks_gpa: IMarksGPA;
+  marks_gpa: MarksGPA;
 
   @Prop({ required: false })
   field_of_study?: string;
@@ -63,13 +76,17 @@ export class EducationalBackground implements IEducationalBackground {
   transcript?: string;
 }
 
-// typescript namespace with all the user type enums
-export namespace UserNS {
-  export enum UserType {
-    Student = 'Student',
-    Admin = 'Admin',
-    Campus_Admin = 'Campus_Admin',
-  }
+// Schema Class for national id card
+@Schema({
+  timestamps: false,
+  _id: false,
+})
+export class NationalIdCard implements UserNS.INationalIdCard {
+  @Prop({ required: false })
+  front_side?: string;
+
+  @Prop({ required: false })
+  back_side?: string;
 }
 
 // Add the comparePassword method to the interface
@@ -99,9 +116,9 @@ export class User {
 
   @Prop({
     type: String,
-    enum: FatherLivingStatusEnum,
+    enum: LivingStatusEnum,
   })
-  father_status?: FatherLivingStatusEnum;
+  father_status?: LivingStatusEnum;
 
   @Prop()
   father_income?: string;
@@ -112,8 +129,11 @@ export class User {
   @Prop()
   mother_profession?: string;
 
-  @Prop({ enum: ['alive', 'deceased'] })
-  mother_status?: string;
+  @Prop({
+    type: String,
+    enum: LivingStatusEnum,
+  })
+  mother_status?: LivingStatusEnum;
 
   @Prop()
   mother_income?: string;
@@ -191,10 +211,10 @@ export class User {
   profile_image_url?: string;
 
   @Prop({ type: [EducationalBackground], default: [] })
-  educational_backgrounds: IEducationalBackground[];
+  educational_backgrounds: EducationalBackground[];
 
-  @Prop({ type: MongooseSchema.Types.Mixed })
-  national_id_card: any;
+  @Prop({ type: NationalIdCard, required: true })
+  national_id_card: NationalIdCard;
 
   @Prop({ default: () => new Date() })
   created_at: Date;

--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -1,6 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Schema as MongooseSchema } from 'mongoose';
 import * as bcrypt from 'bcryptjs';
+import { Document } from 'mongoose';
 import { LivingStatusEnum } from 'src/common/constants/shared.constants';
 
 // typescript namespace with all the user type enums


### PR DESCRIPTION
- Admission Redirect Tracking API
	- create a document of `external_application` application in DB
	- and update the admission program's `redirected_students` field with the user's id who applied on it externally
	- change the `admission_programs/by-id/:adm_prg_id`
		- API path changed to `admission_programs/:adm_prg_id`
		- property  `was_redirected` is added on request-time for the requesting user, which the client can use to conditionally modify UI to indicate the external application button was clicked previously. 
		- endpoint is made `protected` and therefore will not be accessible by unauthenticated user
	- Refactoring/Improvements:
		- created `populateDto` for reusability in queryDtos
		- updated the nested objects in the `User` Schema and DTO with Proper Nested Schemas and DTOs instead of using `any` type and `mixed`/ `object` schema types