### PR TITLE
Feat/shahzeb/sb-330: Analytics API for Applications, External Applications & Scholarship Applications

### DIFF
--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -7,6 +7,8 @@ import { AnalyticsController } from './controllers/analytics.controller';
 import { SearchHistoryAnalyticsService } from './services/search-history.analytics.service';
 import { ConversationModelModule } from 'src/chat/conversation-models.module';
 import { ExternalApplicationsModule } from 'src/external-applications/external-applications.module';
+import { ApplicationsModule } from 'src/applications/applications.module';
+import { StudentScholarshipsModule } from 'src/student-scholarships/student-scholarships.module';
 
 @Module({
   imports: [
@@ -14,6 +16,8 @@ import { ExternalApplicationsModule } from 'src/external-applications/external-a
     UniversityModelsModule,
     ConversationModelModule,
     ExternalApplicationsModule,
+    ApplicationsModule,
+    StudentScholarshipsModule,
   ],
   controllers: [AnalyticsController],
   providers: [

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -6,11 +6,21 @@ import { ElasticsearchModule } from '../elasticsearch/elasticsearch.module';
 import { AnalyticsController } from './controllers/analytics.controller';
 import { SearchHistoryAnalyticsService } from './services/search-history.analytics.service';
 import { ConversationModelModule } from 'src/chat/conversation-models.module';
+import { ExternalApplicationsModule } from 'src/external-applications/external-applications.module';
 
 @Module({
-  imports: [ElasticsearchModule, UniversityModelsModule, ConversationModelModule],
+  imports: [
+    ElasticsearchModule,
+    UniversityModelsModule,
+    ConversationModelModule,
+    ExternalApplicationsModule,
+  ],
   controllers: [AnalyticsController],
-  providers: [SearchHistoryAnalyticsService, ApplicationMetricsAnalyticsService, ChatAnalyticsService],
+  providers: [
+    SearchHistoryAnalyticsService,
+    ApplicationMetricsAnalyticsService,
+    ChatAnalyticsService,
+  ],
   exports: [SearchHistoryAnalyticsService],
 })
-export class AnalyticsModule {} 
+export class AnalyticsModule {}

--- a/src/analytics/controllers/analytics.controller.ts
+++ b/src/analytics/controllers/analytics.controller.ts
@@ -18,6 +18,7 @@ import { ResourceProtectionGuard } from 'src/auth/guards/resource-protection.gua
 import { AuthReq } from 'src/auth/decorators/auth-req.decorator';
 import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
 import { ResponseInterceptor } from '../../common/interceptors/response.interceptor';
+import { ExternalApplicationsService } from 'src/external-applications/external-applications.service';
 
 // Authenticated with Guard
 @UseGuards(ResourceProtectionGuard)
@@ -28,6 +29,7 @@ export class AnalyticsController {
     private readonly searchHistoryAnalyticsService: SearchHistoryAnalyticsService,
     private readonly applicationMetricsAnalyticsService: ApplicationMetricsAnalyticsService,
     private readonly chatAnalyticsService: ChatAnalyticsService,
+    private readonly externalApplicationsService: ExternalApplicationsService,
   ) {}
 
   @Get('search-trends/most-searched-degree-levels')
@@ -70,7 +72,9 @@ export class AnalyticsController {
 
   @Get('application-metrics/daily-breakdown')
   async getDailyApplicationMetrics(@Query() query: QueryAnalyticsCommonDto) {
-    return this.applicationMetricsAnalyticsService.getDailyApplicationMetrics(query);
+    return this.applicationMetricsAnalyticsService.getDailyApplicationMetrics(
+      query,
+    );
   }
 
   @Post('application-metrics/register-event')
@@ -126,5 +130,10 @@ export class AnalyticsController {
     return this.chatAnalyticsService.getResponseAnalyticsForAllCampuses(
       !isNaN(parsedLimit) && parsedLimit > 0 ? parsedLimit : 10,
     );
+  }
+
+  @Get('external-applications')
+  async getExternalApplicationsAnalytics() {
+    return this.externalApplicationsService.getAnalytics();
   }
 }

--- a/src/analytics/controllers/analytics.controller.ts
+++ b/src/analytics/controllers/analytics.controller.ts
@@ -23,6 +23,7 @@ import { ApplicationsService } from 'src/applications/services/applications.serv
 import { StudentScholarshipsService } from 'src/student-scholarships/services/student-scholarships.service';
 
 // Authenticated with Guard
+// TODO: Refactor into smaller controllers i.e. SearchTrendsAnalyticsController, ApplicationAnalyticsController, ExternalProgramApplicationAnalyticsController, etc.
 @UseGuards(ResourceProtectionGuard)
 @UseInterceptors(ResponseInterceptor)
 @Controller('analytics')

--- a/src/analytics/controllers/analytics.controller.ts
+++ b/src/analytics/controllers/analytics.controller.ts
@@ -19,6 +19,8 @@ import { AuthReq } from 'src/auth/decorators/auth-req.decorator';
 import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
 import { ResponseInterceptor } from '../../common/interceptors/response.interceptor';
 import { ExternalApplicationsService } from 'src/external-applications/external-applications.service';
+import { ApplicationsService } from 'src/applications/services/applications.service';
+import { StudentScholarshipsService } from 'src/student-scholarships/services/student-scholarships.service';
 
 // Authenticated with Guard
 @UseGuards(ResourceProtectionGuard)
@@ -30,6 +32,8 @@ export class AnalyticsController {
     private readonly applicationMetricsAnalyticsService: ApplicationMetricsAnalyticsService,
     private readonly chatAnalyticsService: ChatAnalyticsService,
     private readonly externalApplicationsService: ExternalApplicationsService,
+    private readonly applicationsService: ApplicationsService,
+    private readonly studentScholarshipsService: StudentScholarshipsService,
   ) {}
 
   @Get('search-trends/most-searched-degree-levels')
@@ -132,8 +136,18 @@ export class AnalyticsController {
     );
   }
 
-  @Get('external-applications')
+  @Get('external-program-applications')
   async getExternalApplicationsAnalytics() {
     return this.externalApplicationsService.getAnalytics();
+  }
+
+  @Get('program-applications')
+  async getApplicationsAnalytics() {
+    return this.applicationsService.getApplicationsAnalytics();
+  }
+
+  @Get('scholarship-applications')
+  async getScholarshipApplicationsAnalytics() {
+    return this.studentScholarshipsService.getScholarshipApplicationsAnalytics();
   }
 }

--- a/src/external-applications/dto/create-external-application.dto.ts
+++ b/src/external-applications/dto/create-external-application.dto.ts
@@ -12,6 +12,11 @@ export class CreateExternalApplicationDto {
   @IsNotEmpty() // required
   @IsObjectId()
   @ToObjectId()
+  university: Types.ObjectId;
+
+  @IsNotEmpty() // required
+  @IsObjectId()
+  @ToObjectId()
   campus: Types.ObjectId;
 
   @IsNotEmpty() // required

--- a/src/external-applications/external-applications.service.ts
+++ b/src/external-applications/external-applications.service.ts
@@ -122,7 +122,7 @@ export class ExternalApplicationsService {
     user: AuthenticatedRequest['user'],
     createExternalApplicationDto: CreateExternalApplicationDto,
   ) {
-    const { program, admission, admission_program, campus } =
+    const { program, admission, admission_program, campus, university } =
       createExternalApplicationDto;
 
     const applicant_snapshot = this.createApplicantSnapshot(user);
@@ -134,6 +134,7 @@ export class ExternalApplicationsService {
       admission,
       admission_program,
       campus,
+      university,
     };
 
     // Start a transaction session

--- a/src/external-applications/schemas/external-application.schema.ts
+++ b/src/external-applications/schemas/external-application.schema.ts
@@ -25,6 +25,9 @@ export class ExternalApplication {
   @Prop({ type: Types.ObjectId, ref: 'Campus', required: true })
   campus: Types.ObjectId;
 
+  @Prop({ type: Types.ObjectId, ref: 'University', required: true })
+  university: Types.ObjectId;
+
   @Prop({ type: Object, required: true })
   applicant_snapshot: ApplicantSnapshot;
 }


### PR DESCRIPTION
- Analytics API for external-applications
	- to get a total count of external applications
	- to get a total count of per-university external applications

- Profile stats
	- API to get `in_progress` applications
	- API to get `applied` applications ("on platform" applications only)
	- API to get `applied` scholarships