### PR TITLE
feat(auth): Add method to extract minimal user information

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -28,6 +28,23 @@ export type SanitizedUser = BetterOmit<
   'hash' | 'salt' | 'password'
 >;
 
+type MinimalUserInfo = Pick<
+  SanitizedUser,
+  | 'first_name'
+  | 'last_name'
+  | 'email'
+  | '_id'
+  | 'user_type'
+  | 'campus_id'
+  | 'profile_image_url'
+  | 'special_person'
+  | 'current_stage'
+  | 'nationality'
+  | 'user_profile_id'
+  | 'university_id'
+  | 'phone_number'
+>;
+
 @Injectable()
 export class AuthService {
   constructor(
@@ -42,6 +59,40 @@ export class AuthService {
       userObject;
 
     return userObjectWithoutSensitiveData;
+  }
+
+  // TODO: Create a method to return MinimalUserInfo from a SanitizedUser
+  private getMinimalUserInfo(user: SanitizedUser): MinimalUserInfo {
+    const {
+      first_name,
+      last_name,
+      email,
+      _id,
+      user_type,
+      campus_id,
+      profile_image_url,
+      special_person,
+      current_stage,
+      nationality,
+      user_profile_id,
+      university_id,
+      phone_number,
+    } = user;
+    return {
+      first_name,
+      last_name,
+      email,
+      _id,
+      user_type,
+      campus_id,
+      profile_image_url,
+      special_person,
+      current_stage,
+      nationality,
+      user_profile_id,
+      university_id,
+      phone_number,
+    };
   }
 
   /**
@@ -142,10 +193,14 @@ export class AuthService {
     const refreshTokenHash = await bcrypt.hash(refreshToken, 10);
     await this.usersService.update(user._id, { refreshTokenHash });
 
+    const minimalUserInfo = this.getMinimalUserInfo(user);
+
     return {
-      token: accessToken, // for backward compatibility
+      user: minimalUserInfo,
       accessToken,
       refreshToken,
+      // For Backward compatibility. Frontend should not use these fields
+      token: accessToken,
       userId: user._id,
       username: user.email,
     };


### PR DESCRIPTION
This pull request enhances the authentication service by introducing a more secure and efficient way to handle user data in authentication responses. Instead of returning the entire sanitized user object upon successful login, this change provides a minimal set of essential user information, reducing data exposure and streamlining the payload.

This is associated with Jira ticket: [SB-384](https://pickysolutions.atlassian.net/browse/SB-384?atlOrigin=eyJpIjoiYzRkMjJlODg3YWZiNGJhODgyYmYwNzMxMzA0YzUyZjMiLCJwIjoiaiJ9)

### Key Changes:

*   **`MinimalUserInfo` Type:** Introduced a new type, `MinimalUserInfo`, which defines a subset of essential user fields required by the frontend after authentication.
*   **`getMinimalUserInfo` Method:** Implemented a private helper method, `getMinimalUserInfo`, within the `AuthService` to extract and structure this minimal user information from the sanitized user object.
*   **Updated Auth Response:** The authentication response payload has been updated to include a `user` object containing the `MinimalUserInfo`.
*   **Backward Compatibility:** The existing `token`, `userId`, and `username` fields are retained in the response to ensure existing frontend functionality does not break. These fields are now marked for future deprecation.