### PR TITLE
refactor(users): remove _id field from EducationalBackground and NationalIdCard schemas

### DIFF
--- a/src/users/schemas/user.schema.ts
+++ b/src/users/schemas/user.schema.ts
@@ -49,7 +49,6 @@ export class MarksGPA implements UserNS.IMarksGPA {
 // Schema Class for educational background
 @Schema({
   timestamps: false,
-  _id: false,
 })
 export class EducationalBackground implements UserNS.IEducationalBackground {
   @Prop({ required: false })
@@ -80,7 +79,6 @@ export class EducationalBackground implements UserNS.IEducationalBackground {
 // Schema Class for national id card
 @Schema({
   timestamps: false,
-  _id: false,
 })
 export class NationalIdCard implements UserNS.INationalIdCard {
   @Prop({ required: false })


### PR DESCRIPTION
- Eliminated the _id field from both EducationalBackground and NationalIdCard schema definitions to streamline the data structure.
- Updated the schemas to enhance consistency and maintainability across user-related models.