### PR TITLE
Fix: Escape Special Regex Characters in `programName` Filter for Admission Programs Endpoint

### DIFF
--- a/src/admission-programs/services/admission-programs.service.ts
+++ b/src/admission-programs/services/admission-programs.service.ts
@@ -24,6 +24,7 @@ import {
 } from '../schemas/admission-program.schema';
 import { AuthenticatedRequest } from 'src/auth/types/auth.interface';
 import { QueryAdmissionProgramByIdDto } from '../dto/query-admission-program.dto';
+import { escapeRegex } from 'src/utils/db.utils';
 
 @Injectable()
 export class AdmissionProgramsService {
@@ -816,8 +817,14 @@ export class AdmissionProgramsService {
       });
     if (programName)
       pipeline.push({
-        $match: { 'program.name': { $regex: programName, $options: 'i' } },
+        $match: {
+          'program.name': {
+            $regex: escapeRegex(programName),
+            $options: 'i',
+          },
+        },
       });
+
     if (university)
       pipeline.push({
         $match: { 'admission.university_id': { $eq: university } },

--- a/src/utils/db.utils.ts
+++ b/src/utils/db.utils.ts
@@ -1,35 +1,71 @@
-import { PipelineStage, Types} from "mongoose";
+import { PipelineStage, Types } from 'mongoose';
 
 export const stringToObjectId = (id: string) => {
-    return new /* Schema. */Types.ObjectId(id);
-}
+  return new /* Schema. */ Types.ObjectId(id);
+};
 
 export const verifyStringObjectId = (id: string) => {
   return Types.ObjectId.isValid(id);
 };
 
-
 export const getSortOrder = (sortOrder: 'asc' | 'desc') => {
-    return sortOrder == 'asc' ? 1 : -1;
-}
+  return sortOrder == 'asc' ? 1 : -1;
+};
 
 // Create the agg pipeline based on the filterPipeline but separate the data and count pipelines
 export const getDataAndCountAggPipeline = (
-    filterPipeline: PipelineStage[],
-    sort: Record<string, any>,
-    limit: number,
-    skip: number,
-    countKey: string = 'total'
+  filterPipeline: PipelineStage[],
+  sort: Record<string, any>,
+  limit: number,
+  skip: number,
+  countKey: string = 'total',
 ) => {
-    const dataPipeline: PipelineStage[] = [
-        ...filterPipeline,
-        { $sort: sort },
-        { $skip: skip },
-        { $limit: limit }
-    ];
-    const countPipeline: PipelineStage[] = [
-        ...filterPipeline,
-        { $count: countKey }
-    ];
-    return { dataPipeline, countPipeline };
-}
+  const dataPipeline: PipelineStage[] = [
+    ...filterPipeline,
+    { $sort: sort },
+    { $skip: skip },
+    { $limit: limit },
+  ];
+  const countPipeline: PipelineStage[] = [
+    ...filterPipeline,
+    { $count: countKey },
+  ];
+  return { dataPipeline, countPipeline };
+};
+
+/**
+ * Escapes a string for use in a regular expression pattern for MongoDB queries.
+ *
+ * ## Why this utility exists:
+ * When using user input in MongoDB $regex queries, special regex characters (such as (), [], ., *, +, ?, etc.)
+ * can change the meaning of the search or even break the query. This utility ensures that user input is treated as a literal string,
+ * not as a regex pattern, by escaping all special regex characters.
+ *
+ * ## Problem it solves:
+ * - Prevents regex injection attacks and unintended matches.
+ * - Ensures user searches behave as expected, matching the literal input string.
+ * - Avoids bugs where valid-looking input fails to match due to unescaped special characters.
+ *
+ * ## What happens if this is not used:
+ * - User input containing special regex characters may result in incorrect, unexpected, or even dangerous query behavior.
+ * - For example, searching for "BS (Computer Science) - COMSATS Isb" without escaping will treat the parentheses as regex groupings, not as literal characters.
+ *
+ * ## Example:
+ *
+ * //*  Without escaping:
+ * const userInput = "BS (Computer Science) - COMSATS Isb";
+ * const query = { name: { $regex: userInput, $options: 'i' } };
+ * //* This will NOT match documents with the literal string, unless the parentheses are interpreted as regex groups.
+ *
+ * //* With escaping:
+ * const userInput = "BS (Computer Science) - COMSATS Isb";
+ * const safeInput = escapeRegex(userInput);
+ * const query = { name: { $regex: safeInput, $options: 'i' } };
+ * //* This will match documents containing the exact string, including parentheses.
+ *
+ * @param str - The string to escape
+ * @returns The escaped string, safe for use in a regex
+ */
+export const escapeRegex = (str: string): string => {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};


### PR DESCRIPTION
### :mag: Investigation Summary

- While investigating why certain program searches (e.g., `BS (Computer Science) - COMSATS Isb`) were not returning results, it was discovered that user input containing special regex characters (such as parentheses) was being passed directly to MongoDB's `$regex` operator.
- This caused the search to interpret these characters as regex patterns rather than literal strings, resulting in no matches for valid queries.
- The investigation included:
  - Reviewing the aggregation pipeline in the backend service.
  - Testing queries in MongoDB Compass with and without escaping special characters.
  - Verifying that escaping special characters in the regex pattern resolved the issue and returned the expected results.

---

### :wrench: Changes Made

- **Utility Enhancement:**  
  Added and documented an `escapeRegex` utility in `db.utils.ts` to safely escape all special regex characters in user input.
- **Service Update:**  
  Updated the `AdmissionProgramsService` to use `escapeRegex` when building the `$regex` filter for `programName` in the aggregation pipeline.
- **Documentation:**  
  Improved documentation for the `escapeRegex` utility, including:
  - The reason for its creation.
  - The problem it solves.
  - What happens if it is not used.
  - Example usage (with and without escaping).

---

### :warning: Scope & Future Work

- **This PR only addresses the issue for the `admission-programs/with-filters` endpoint.**
- **Other endpoints using `$regex` with user input may be similarly vulnerable or buggy.**
- Due to current workload and priorities, only this endpoint is fixed in this PR.
- **This PR should serve as a benchmark and reference for addressing similar issues elsewhere in the codebase in the future.**

---

### :white_check_mark: How to Test

1. Search for a program with special characters in the name (e.g., parentheses, dots, etc.) via the affected endpoint.
2. Confirm that results are now returned as expected.
3. Review the new utility and its documentation for clarity and future use.

---

**Related resources:**  
- [Jira Ticket SB-415](https://pickysolutions.atlassian.net/browse/SB-415?atlOrigin=eyJpIjoiMTIxNzMxYjFiYzFlNDYxZGIzMDYyODc1NzQ3NmUzMWYiLCJwIjoiaiJ9)
- [MongoDB $regex documentation](https://www.mongodb.com/docs/manual/reference/operator/query/regex/)

---