### PR TITLE
fix: minimize auth token responese size and ensure expiration of reset password token link

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -193,9 +193,10 @@ export class AuthService {
 
   async refreshToken(user: UserDocument) {
     const sanitizedUser = await this.sanitizeUser(user);
+    const minimalUserInfo = this.getMinimalUserInfo(sanitizedUser);
 
     const { accessToken, refreshToken } =
-      await this.generateTokens(sanitizedUser);
+      await this.generateTokens(minimalUserInfo);
 
     // BUG: Using bcrypt was giving unexpected results
     // const refreshTokenHash = await argon2.hash(refreshToken);

--- a/src/auth/types/auth.interface.ts
+++ b/src/auth/types/auth.interface.ts
@@ -1,9 +1,9 @@
 import { Request } from 'express';
-import { ResourceProtectionStrategy } from 'src/auth/strategies/resource-protection.strategy';
-import { LocalAuthenticationStrategy } from '../strategies/local-authentication.strategy';
 import { Socket } from 'socket.io';
-import { BetterOmit } from 'src/utils/typescript.utils';
+import { ResourceProtectionStrategy } from 'src/auth/strategies/resource-protection.strategy';
 import { User } from 'src/users/schemas/user.schema';
+import { BetterOmit } from 'src/utils/typescript.utils';
+import { LocalAuthenticationStrategy } from '../strategies/local-authentication.strategy';
 
 export type UserWithoutComparePassword = BetterOmit<User, 'comparePassword'> & {
   _id: string;
@@ -15,7 +15,6 @@ export type SanitizedUser = BetterOmit<
 
 export type MinimalUserInfo = Pick<
   SanitizedUser,
-  | 'first_name'
   | 'first_name'
   | 'last_name'
   | 'email'


### PR DESCRIPTION
Token Respone Size issue:
- client uses cookies to store auth token
- token used to contain too much data of the usr
- this bloated the token size beyond the allowed 4Kb limit
- a previous PR minimized the token size of login response
- this PR minimizes the token size of refreshed auth tokens


Reset Password Expiration
- ensure that the reset password link is removed after the user attempts to reset password


fixes 2 Jira Tickets SB-517 (https://pickysolutions.atlassian.net/browse/SB-517) , SB-529 (https://pickysolutions.atlassian.net/browse/SB-529)